### PR TITLE
Use a different delimiter to build the translation map.

### DIFF
--- a/__tests__/parsers/json-parser.test.ts
+++ b/__tests__/parsers/json-parser.test.ts
@@ -19,9 +19,9 @@ const content = JSON.stringify(
 test('JSON PARSER: correctly parses from string', async () => {
     const file = await parser.parseFrom(content);
     expect(file).toBeTruthy();
-    expect(file['messages[--]foo[--]msg1']).toEqual('hello {{variable}}');
-    expect(file['messages[--]foo[--]msg2']).toEqual('world');
-    expect(file['messages[--]bar']).toEqual('John');
+    expect(file[`messages${JsonParser.DELIMITER}foo${JsonParser.DELIMITER}msg1`]).toEqual('hello {{variable}}');
+    expect(file[`messages${JsonParser.DELIMITER}foo${JsonParser.DELIMITER}msg2`]).toEqual('world');
+    expect(file[`messages${JsonParser.DELIMITER}bar`]).toEqual('John');
     expect(file['msg3']).toEqual('Doe');
     expect(file['msg.4']).toEqual('this is a fullstop.');
     expect(file['msg.5.']).toEqual('this is a fullstop. With another sentance.');
@@ -44,9 +44,9 @@ test('JSON PARSER: correctly applies translations', async () => {
     });
 
     expect(result).toBeTruthy();
-    expect(file['messages[--]foo[--]msg1']).toEqual('hello {{variable}}');
-    expect(file['messages[--]foo[--]msg2']).toEqual('Does this work?');
-    expect(file['messages[--]bar']).toEqual('John');
+    expect(file[`messages${JsonParser.DELIMITER}foo${JsonParser.DELIMITER}msg1`]).toEqual('hello {{variable}}');
+    expect(file[`messages${JsonParser.DELIMITER}foo${JsonParser.DELIMITER}msg2`]).toEqual('Does this work?');
+    expect(file[`messages${JsonParser.DELIMITER}bar`]).toEqual('John');
     expect(file['msg3']).toEqual('Doe');
     expect(file['msg.4']).toEqual('this is a fullstop.');
     expect(file['msg.5.']).toEqual('this is a fullstop. With another sentance.');
@@ -58,9 +58,9 @@ test('JSON PARSER: correctly creates translatable text map', async () => {
 
     const translatableTextMap = parser.toTranslatableTextMap(file);
     expect(translatableTextMap).toBeTruthy();
-    expect(translatableTextMap.text.get('messages[--]foo[--]msg1')).toEqual('hello {{variable}}');
-    expect(translatableTextMap.text.get('messages[--]foo[--]msg2')).toEqual('world');
-    expect(translatableTextMap.text.get('messages[--]bar')).toEqual('John');
+    expect(translatableTextMap.text.get(`messages${JsonParser.DELIMITER}foo${JsonParser.DELIMITER}msg1`)).toEqual('hello {{variable}}');
+    expect(translatableTextMap.text.get(`messages${JsonParser.DELIMITER}foo${JsonParser.DELIMITER}msg2`)).toEqual('world');
+    expect(translatableTextMap.text.get(`messages${JsonParser.DELIMITER}bar`)).toEqual('John');
     expect(translatableTextMap.text.get('msg3')).toEqual('Doe');
     expect(translatableTextMap.text.get('msg.4')).toEqual('this is a fullstop.');
     expect(translatableTextMap.text.get('msg.5.')).toEqual('this is a fullstop. With another sentance.');

--- a/__tests__/parsers/json-parser.test.ts
+++ b/__tests__/parsers/json-parser.test.ts
@@ -12,8 +12,8 @@ const content = JSON.stringify(
             },
         },
         msg3: "Doe",
-        msg4: "this is a fullstop.",
-        msg5: "this is a fullstop. With another sentance."
+        "msg.4": "this is a fullstop.",
+        "msg.5.": "this is a fullstop. With another sentance."
     }, null, '\t');
 
 test('JSON PARSER: correctly parses from string', async () => {
@@ -23,8 +23,8 @@ test('JSON PARSER: correctly parses from string', async () => {
     expect(file['messages[--]foo[--]msg2']).toEqual('world');
     expect(file['messages[--]bar']).toEqual('John');
     expect(file['msg3']).toEqual('Doe');
-    expect(file['msg4']).toEqual('this is a fullstop.');
-    expect(file['msg5']).toEqual('this is a fullstop. With another sentance.');
+    expect(file['msg.4']).toEqual('this is a fullstop.');
+    expect(file['msg.5.']).toEqual('this is a fullstop. With another sentance.');
 });
 
 test('JSON PARSER: correctly formats back as string', async () => {
@@ -48,8 +48,8 @@ test('JSON PARSER: correctly applies translations', async () => {
     expect(file['messages[--]foo[--]msg2']).toEqual('Does this work?');
     expect(file['messages[--]bar']).toEqual('John');
     expect(file['msg3']).toEqual('Doe');
-    expect(file['msg4']).toEqual('this is a fullstop.');
-    expect(file['msg5']).toEqual('this is a fullstop. With another sentance.');
+    expect(file['msg.4']).toEqual('this is a fullstop.');
+    expect(file['msg.5.']).toEqual('this is a fullstop. With another sentance.');
 });
 
 test('JSON PARSER: correctly creates translatable text map', async () => {
@@ -62,6 +62,6 @@ test('JSON PARSER: correctly creates translatable text map', async () => {
     expect(translatableTextMap.text.get('messages[--]foo[--]msg2')).toEqual('world');
     expect(translatableTextMap.text.get('messages[--]bar')).toEqual('John');
     expect(translatableTextMap.text.get('msg3')).toEqual('Doe');
-    expect(translatableTextMap.text.get('msg4')).toEqual('this is a fullstop.');
-    expect(translatableTextMap.text.get('msg5')).toEqual('this is a fullstop. With another sentance.');
+    expect(translatableTextMap.text.get('msg.4')).toEqual('this is a fullstop.');
+    expect(translatableTextMap.text.get('msg.5.')).toEqual('this is a fullstop. With another sentance.');
 });

--- a/__tests__/parsers/json-parser.test.ts
+++ b/__tests__/parsers/json-parser.test.ts
@@ -11,16 +11,20 @@ const content = JSON.stringify(
                 msg2: "world"
             },
         },
-        msg3: "Doe"
+        msg3: "Doe",
+        msg4: "this is a fullstop.",
+        msg5: "this is a fullstop. With another sentance."
     }, null, '\t');
 
 test('JSON PARSER: correctly parses from string', async () => {
     const file = await parser.parseFrom(content);
     expect(file).toBeTruthy();
-    expect(file['messages.foo.msg1']).toEqual('hello {{variable}}');
-    expect(file['messages.foo.msg2']).toEqual('world');
-    expect(file['messages.bar']).toEqual('John');
+    expect(file['messages[--]foo[--]msg1']).toEqual('hello {{variable}}');
+    expect(file['messages[--]foo[--]msg2']).toEqual('world');
+    expect(file['messages[--]bar']).toEqual('John');
     expect(file['msg3']).toEqual('Doe');
+    expect(file['msg4']).toEqual('this is a fullstop.');
+    expect(file['msg5']).toEqual('this is a fullstop. With another sentance.');
 });
 
 test('JSON PARSER: correctly formats back as string', async () => {
@@ -36,14 +40,16 @@ test('JSON PARSER: correctly applies translations', async () => {
     expect(file).toBeTruthy();
 
     const result = parser.applyTranslations(file, {
-        'messages.foo.msg2': 'Does this work?'
+        'messages[--]foo[--]msg2': 'Does this work?'
     });
 
     expect(result).toBeTruthy();
-    expect(file['messages.foo.msg1']).toEqual('hello {{variable}}');
-    expect(file['messages.foo.msg2']).toEqual('Does this work?');
-    expect(file['messages.bar']).toEqual('John');
+    expect(file['messages[--]foo[--]msg1']).toEqual('hello {{variable}}');
+    expect(file['messages[--]foo[--]msg2']).toEqual('Does this work?');
+    expect(file['messages[--]bar']).toEqual('John');
     expect(file['msg3']).toEqual('Doe');
+    expect(file['msg4']).toEqual('this is a fullstop.');
+    expect(file['msg5']).toEqual('this is a fullstop. With another sentance.');
 });
 
 test('JSON PARSER: correctly creates translatable text map', async () => {
@@ -52,8 +58,10 @@ test('JSON PARSER: correctly creates translatable text map', async () => {
 
     const translatableTextMap = parser.toTranslatableTextMap(file);
     expect(translatableTextMap).toBeTruthy();
-    expect(translatableTextMap.text.get('messages.foo.msg1')).toEqual('hello {{variable}}');
-    expect(translatableTextMap.text.get('messages.foo.msg2')).toEqual('world');
-    expect(translatableTextMap.text.get('messages.bar')).toEqual('John');
+    expect(translatableTextMap.text.get('messages[--]foo[--]msg1')).toEqual('hello {{variable}}');
+    expect(translatableTextMap.text.get('messages[--]foo[--]msg2')).toEqual('world');
+    expect(translatableTextMap.text.get('messages[--]bar')).toEqual('John');
     expect(translatableTextMap.text.get('msg3')).toEqual('Doe');
+    expect(translatableTextMap.text.get('msg4')).toEqual('this is a fullstop.');
+    expect(translatableTextMap.text.get('msg5')).toEqual('this is a fullstop. With another sentance.');
 });

--- a/dist/resource-translator/index.js
+++ b/dist/resource-translator/index.js
@@ -3958,7 +3958,7 @@ class JsonParser {
     parseFrom(fileContent) {
         const buildMap = (obj, parentPath) => {
             for (const [key, value] of Object.entries(obj)) {
-                const path = parentPath ? `${parentPath}[--]${key}` : key;
+                const path = parentPath ? `${parentPath}${JsonParser.DELIMITER}${key}` : key;
                 if (typeof value === "string") {
                     map.set(path, value);
                 }
@@ -3989,7 +3989,7 @@ class JsonParser {
             }
         };
         for (const [key, value] of Object.entries(instance)) {
-            const keyParts = key.split("[--]");
+            const keyParts = key.split(JsonParser.DELIMITER);
             buildObject(content, keyParts, value);
         }
         return JSON.stringify(content, null, "\t");
@@ -4016,6 +4016,7 @@ class JsonParser {
     }
 }
 exports.JsonParser = JsonParser;
+JsonParser.DELIMITER = '[--]';
 
 
 /***/ }),

--- a/src/parsers/json-parser.ts
+++ b/src/parsers/json-parser.ts
@@ -3,10 +3,13 @@ import { JsonFile } from "../file-formats/json-file";
 import { TranslationFileParser } from "./translation-file-parser";
 
 export class JsonParser implements TranslationFileParser {
+
+    static DELIMITER: string = '[--]';
+
     parseFrom(fileContent: string): Promise<JsonFile> {
         const buildMap = (obj: any, parentPath?: string) => {
             for (const [key, value] of Object.entries(obj)) {
-                const path = parentPath ? `${parentPath}[--]${key}` : key;
+                const path = parentPath ? `${parentPath}${JsonParser.DELIMITER}${key}` : key;
                 if (typeof value === "string") {
                     map.set(path, value);
                 } else {
@@ -41,7 +44,7 @@ export class JsonParser implements TranslationFileParser {
         };
 
         for (const [key, value] of Object.entries(instance)) {
-            const keyParts = key.split("[--]");
+            const keyParts = key.split(JsonParser.DELIMITER);
             buildObject(content, keyParts, value);
         }
 

--- a/src/parsers/json-parser.ts
+++ b/src/parsers/json-parser.ts
@@ -6,7 +6,7 @@ export class JsonParser implements TranslationFileParser {
     parseFrom(fileContent: string): Promise<JsonFile> {
         const buildMap = (obj: any, parentPath?: string) => {
             for (const [key, value] of Object.entries(obj)) {
-                const path = parentPath ? `${parentPath}.${key}` : key;
+                const path = parentPath ? `${parentPath}[--]${key}` : key;
                 if (typeof value === "string") {
                     map.set(path, value);
                 } else {
@@ -41,7 +41,7 @@ export class JsonParser implements TranslationFileParser {
         };
 
         for (const [key, value] of Object.entries(instance)) {
-            const keyParts = key.split(".");
+            const keyParts = key.split("[--]");
             buildObject(content, keyParts, value);
         }
 


### PR DESCRIPTION
In the current version, it is not possible to have a translation key with a `.`. A different delimiter when building the translation map makes this work. Currently using `[--]`, not sure if this is very practical but it is a pretty high chance that this will not be inside of a translation key.

Fixes #32