### PR TITLE
docs: credit Azure SDK migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Translator client now uses the official Azure SDK.** Replaced the
+  hand-rolled `axios`-based REST client with
+  [`@azure-rest/ai-translation-text`](https://www.npmjs.com/package/@azure-rest/ai-translation-text)
+  on top of `@azure/core-rest-pipeline`. Retries on 408/429/5xx, auth
+  header injection, error envelope parsing, and request/response typing
+  are now handled by the SDK. Public action behaviour and inputs are
+  unchanged. Net bundle size dropped ~280 KB after dropping `axios`.
+
 ### Added
 
 - New action inputs: `include`, `exclude`, `configPath`, `categoryId`,

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 [![docs](https://img.shields.io/badge/docs-ievangelist.github.io%2Fresource--translator-1f3a8a)](https://ievangelist.github.io/resource-translator/)
 
 A GitHub Action that opens machine-translated pull requests for resource files
-in your repository, powered by **Azure AI Translator**.
+in your repository, powered by **Azure AI Translator** via Microsoft's official
+[`@azure-rest/ai-translation-text`](https://www.npmjs.com/package/@azure-rest/ai-translation-text)
+SDK — built-in retry/throttling, no hand-rolled HTTP clients.
 
 Supported formats: `.resx`, `.xliff`, `.po`, `.json`, `.ini`, `.restext`.
 

--- a/docs/src/pages/faq.astro
+++ b/docs/src/pages/faq.astro
@@ -12,6 +12,24 @@ import PageHero from "../components/PageHero.astro";
     lede="Quick answers to the questions that come up most often when adopting the action."
   />
 
+  <h2>How does the action talk to Azure?</h2>
+  <p>
+    Through Microsoft's official
+    <a
+      href="https://www.npmjs.com/package/@azure-rest/ai-translation-text"
+      rel="noopener"
+      target="_blank"><code>@azure-rest/ai-translation-text</code></a
+    > SDK, layered on
+    <a
+      href="https://www.npmjs.com/package/@azure/core-rest-pipeline"
+      rel="noopener"
+      target="_blank"><code>@azure/core-rest-pipeline</code></a
+    >. That gets you automatic retries on 408/429/5xx, typed request and
+    response models, and authentication header handling for free —
+    everything that used to be a hand-rolled <code>axios</code> call. The
+    public action surface (inputs, outputs, file outputs) is unchanged.
+  </p>
+
   <h2>Why are translations sometimes off-brand or off-tone?</h2>
   <p>
     Machine translation defaults to a general-purpose model. Three knobs help:

--- a/docs/src/pages/getting-started.astro
+++ b/docs/src/pages/getting-started.astro
@@ -44,7 +44,7 @@ jobs:
     eyebrow="Setup"
     title="Getting started"
     icon="lucide:rocket"
-    lede="Add a workflow file, point it at your Azure AI Translator credentials, and the action will scan the repo for source-language resource files and emit translated siblings."
+    lede="Add a workflow file, point it at your Azure AI Translator credentials, and the action — built on Microsoft's official @azure-rest/ai-translation-text SDK — will scan the repo for source-language resource files and emit translated siblings."
   />
   <h2>1. Provision an Azure AI Translator resource</h2>
   <p>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -73,8 +73,8 @@ const features = [
   },
   {
     icon: "lucide:zap",
-    title: "Fast, audit-clean",
-    body: "esbuild-bundled, Node 24 runner, zero npm-audit findings, CI matrix on Ubuntu/Windows/macOS × Node 20/22/24.",
+    title: "Official Azure SDK",
+    body: "Built on @azure-rest/ai-translation-text + @azure/core-rest-pipeline — automatic retries on 408/429/5xx, no hand-rolled HTTP. esbuild-bundled, audit-clean.",
     accent: "from-(--color-accent-500) to-(--color-cool-500)",
   },
 ];
@@ -132,8 +132,9 @@ const formats = [
             machine-translated pull requests for your <code>.resx</code>,
             <code>.xliff</code>, <code>.po</code>, <code>.json</code>,
             <code>.ini</code>, and <code>.restext</code> files using
-            <strong class="text-(--fg)">Azure AI Translator</strong> — no extra
-            services, just a workflow.
+            <strong class="text-(--fg)">Azure AI Translator</strong> via the
+            official <code>@azure-rest/ai-translation-text</code> SDK — no
+            extra services, just a workflow.
           </p>
 
           <div class="mt-9 flex flex-wrap items-center gap-3">
@@ -168,7 +169,7 @@ const formats = [
             </li>
             <li class="inline-flex items-center gap-1.5">
               <Icon name="lucide:check" class="size-3.5 text-(--color-brand-500)" />
-              101 tests
+              150 tests
             </li>
             <li class="inline-flex items-center gap-1.5">
               <Icon name="lucide:check" class="size-3.5 text-(--color-brand-500)" />
@@ -176,7 +177,7 @@ const formats = [
             </li>
             <li class="inline-flex items-center gap-1.5">
               <Icon name="lucide:check" class="size-3.5 text-(--color-brand-500)" />
-              CodeQL on PRs
+              Official Azure SDK
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Surfaces the SDK migration (PR #89, commit 62ff32e) in user-facing docs so anyone landing on the README, the docs site, or the changelog can see what's under the hood.

## What changed

- **README.md** — description line now mentions `@azure-rest/ai-translation-text`.
- **CHANGELOG.md** — new `### Changed` entry under `[Unreleased]` calling out the SDK swap, retry-on-408/429/5xx, and the ~280 KB net dist bundle reduction.
- **docs/src/pages/index.astro** — features grid now has an `Official Azure SDK` card, the hero subtitle credits the SDK, the stale `101 tests` badge bumps to 150, and one of the hero check badges flips from `CodeQL on PRs` to `Official Azure SDK`.
- **docs/src/pages/faq.astro** — new top Q&A: *How does the action talk to Azure?* with links to the SDK and `@azure/core-rest-pipeline` npm pages.
- **docs/src/pages/getting-started.astro** — lede now mentions the SDK in passing.

## Verification

- `cd docs && npm run build` passes (10 pages indexed, pagefind regenerated, exit 0).
- No source/test changes — all behaviour from #89 stays as merged.

## Out of scope

- The `101 tests` count was hardcoded; bumped to 150 here but it'll drift again on the next test addition. Worth a follow-up to inject from `__tests__` somehow, but not in this PR.