### PR TITLE
feat: 429 retry, placeholder protection, and per-key opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `apiVersion`, `dryRun`, `failOnError`, plus advanced Translator request
   knobs `textType`, `profanityAction`, `profanityMarker`, and
   `allowFallback`.
+- **Resilience inputs:** `maxRetries` and `retryBackoffMs` control the
+  retry-on-transient-status loop. Honors Azure's `Retry-After` header
+  exactly when present; otherwise jittered exponential backoff capped
+  at `retryBackoffMs`. Closes #46.
+- **Placeholder protection:** `protectPlaceholders` (on by default) and
+  `customPlaceholderPatterns` shield i18next/Mustache `{{name}}`,
+  ES `${var}`, .NET `{0}`/`{0:N2}`, printf `%s`/`%1$s` and HTML
+  entities from translation. Tightens #16.
+- **Per-key opt-out:** `noTranslatePatterns` glob-matches parser-level
+  keys (JSON dotted path, RESX `name`, PO `msgid`, XLIFF unit `id`,
+  INI/restext key) and skips them in the Translator request, preserving
+  the source value verbatim. Closes #35.
 - Optional repository configuration via `.github/resource-translator.yml`
   (action inputs always win over repo config).
 - Source locale is now always forwarded to Translator as `from=<locale>`

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -473,3 +473,139 @@ test("API: translate handles a typed Translator error response without code/mess
     expect.stringContaining("HTTP 418"),
   );
 });
+
+test("API: translate retries when the Translator returns 429 and eventually succeeds", async () => {
+  // A 429 is "unexpected" per `isUnexpected` AND transient — the wrapper
+  // should sleep and retry until a 200 comes back. Sleep is mocked out via
+  // jest fake timers so the test stays sub-second.
+  mockedIsUnexpected.mockImplementation((response: { status: string }) => {
+    return !String(response?.status ?? "200").startsWith("2");
+  });
+
+  mockPost
+    .mockResolvedValueOnce({
+      status: "429",
+      headers: { "retry-after": "0" },
+      body: { error: { code: 429001, message: "Too many requests" } },
+    })
+    .mockResolvedValueOnce({
+      status: "429",
+      headers: { "retry-after": "0" },
+      body: { error: { code: 429001, message: "Too many requests" } },
+    })
+    .mockResolvedValueOnce({
+      status: "200",
+      body: [{ translations: [{ to: "fr", text: "Salut" }] }],
+    });
+
+  const result = await translate(
+    {
+      endpoint: "https://api.cognitive.microsofttranslator.com/",
+      subscriptionKey: "k",
+    },
+    ["fr"],
+    new Map<string, string>([["Greeting", "Hello"]]),
+    "f.resx",
+    { maxRetries: 5, retryBackoffMs: 0 },
+  );
+
+  expect(result).toBeDefined();
+  expect(mockPost).toHaveBeenCalledTimes(3);
+  const setFailedMock = setFailed as jest.MockedFunction<typeof setFailed>;
+  expect(setFailedMock).not.toHaveBeenCalled();
+});
+
+test("API: translate gives up after maxRetries and surfaces the failure", async () => {
+  mockedIsUnexpected.mockImplementation((response: { status: string }) => {
+    return !String(response?.status ?? "200").startsWith("2");
+  });
+
+  const transient = {
+    status: "429",
+    headers: { "retry-after": "0" },
+    body: { error: { code: 429001, message: "Too many requests" } },
+  };
+  mockPost.mockResolvedValue(transient);
+
+  const result = await translate(
+    {
+      endpoint: "https://api.cognitive.microsofttranslator.com/",
+      subscriptionKey: "k",
+    },
+    ["fr"],
+    new Map<string, string>([["Greeting", "Hello"]]),
+    "f.resx",
+    { maxRetries: 2, retryBackoffMs: 0 },
+  );
+
+  expect(result).toBeUndefined();
+  // Initial call + 2 retries.
+  expect(mockPost).toHaveBeenCalledTimes(3);
+  const setFailedMock = setFailed as jest.MockedFunction<typeof setFailed>;
+  expect(setFailedMock).toHaveBeenCalledWith(
+    expect.stringContaining("Too many requests"),
+  );
+});
+
+test("API: translate protects placeholders before sending and restores them in the response", async () => {
+  // The Translator sees sentinel tokens, never the original `{{name}}`.
+  // The caller sees `{{name}}` round-trip through the translation.
+  mockPost.mockImplementation(({ body }: { body: Array<{ text: string }> }) => {
+    return Promise.resolve({
+      status: "200",
+      body: body.map((entry) => ({
+        translations: [
+          {
+            to: "fr",
+            // Simulate the translator wrapping the (sentinel-bearing) text in
+            // a French phrase. The sentinel is preserved verbatim.
+            text: `Bonjour ${entry.text.replace(/^Hello /, "")}`,
+          },
+        ],
+      })),
+    });
+  });
+
+  const result = await translate(
+    {
+      endpoint: "https://api.cognitive.microsofttranslator.com/",
+      subscriptionKey: "k",
+    },
+    ["fr"],
+    new Map<string, string>([["Greeting", "Hello {{name}}"]]),
+    "f.resx",
+  );
+
+  // The body actually sent to the SDK must NOT contain `{{name}}`.
+  const sentBody = mockPost.mock.calls[0][0].body as Array<{ text: string }>;
+  expect(sentBody[0].text).not.toContain("{{name}}");
+  expect(sentBody[0].text).toMatch(/RTKEEP\d{6}/);
+
+  // The result the caller sees must contain `{{name}}` again.
+  expect(result).toBeDefined();
+  const fr = result?.["fr"];
+  expect(fr).toBeDefined();
+  expect(fr?.["Greeting"]).toBe("Bonjour {{name}}");
+});
+
+test("API: translate skips placeholder protection when protectPlaceholders=false", async () => {
+  mockPost.mockResolvedValueOnce({
+    status: "200",
+    body: [{ translations: [{ to: "fr", text: "Bonjour {{name}}" }] }],
+  });
+
+  await translate(
+    {
+      endpoint: "https://api.cognitive.microsofttranslator.com/",
+      subscriptionKey: "k",
+    },
+    ["fr"],
+    new Map<string, string>([["Greeting", "Hello {{name}}"]]),
+    "f.resx",
+    { protectPlaceholders: false },
+  );
+
+  const sentBody = mockPost.mock.calls[0][0].body as Array<{ text: string }>;
+  expect(sentBody[0].text).toBe("Hello {{name}}");
+  expect(sentBody[0].text).not.toMatch(/RTKEEP\d{6}/);
+});

--- a/__tests__/get-inputs.test.ts
+++ b/__tests__/get-inputs.test.ts
@@ -139,4 +139,57 @@ describe("getInputs", () => {
     setInput("profanityMarker", "Tag");
     expect(() => getInputs()).toThrow(/profanityMarker/);
   });
+
+  it("reads noTranslatePatterns as a multiline list", () => {
+    setInput(
+      "noTranslatePatterns",
+      "errors.code.*\nbrands.*\n\n  whitespace-only-lines-skipped  ",
+    );
+    const inputs = getInputs();
+    expect(inputs.noTranslatePatterns).toEqual([
+      "errors.code.*",
+      "brands.*",
+      "whitespace-only-lines-skipped",
+    ]);
+  });
+
+  it("returns undefined for noTranslatePatterns when not provided", () => {
+    const inputs = getInputs();
+    expect(inputs.noTranslatePatterns).toBeUndefined();
+  });
+
+  it("reads protectPlaceholders as a tri-state boolean", () => {
+    setInput("protectPlaceholders", "false");
+    expect(getInputs().protectPlaceholders).toBe(false);
+    setInput("protectPlaceholders", "true");
+    expect(getInputs().protectPlaceholders).toBe(true);
+    delete inputValues["protectPlaceholders"];
+    expect(getInputs().protectPlaceholders).toBeUndefined();
+  });
+
+  it("reads customPlaceholderPatterns as a multiline list", () => {
+    setInput("customPlaceholderPatterns", "<<.+?>>\n\\$brand\\$");
+    expect(getInputs().customPlaceholderPatterns).toEqual([
+      "<<.+?>>",
+      "\\$brand\\$",
+    ]);
+  });
+
+  it("parses maxRetries and retryBackoffMs as non-negative integers", () => {
+    setInput("maxRetries", "8");
+    setInput("retryBackoffMs", "60000");
+    const inputs = getInputs();
+    expect(inputs.maxRetries).toBe(8);
+    expect(inputs.retryBackoffMs).toBe(60000);
+  });
+
+  it("rejects a non-numeric maxRetries", () => {
+    setInput("maxRetries", "lots");
+    expect(() => getInputs()).toThrow(/maxRetries/);
+  });
+
+  it("rejects a negative retryBackoffMs", () => {
+    setInput("retryBackoffMs", "-5");
+    expect(() => getInputs()).toThrow(/retryBackoffMs/);
+  });
 });

--- a/__tests__/helpers/placeholders.test.ts
+++ b/__tests__/helpers/placeholders.test.ts
@@ -1,0 +1,107 @@
+import { protect, restore } from "../../src/helpers/placeholders";
+
+describe("placeholders.protect/restore", () => {
+  it("round-trips an i18next {{name}} placeholder", () => {
+    const { protected: p, tokens } = protect("Hello {{name}}!");
+    expect(p).not.toContain("{{name}}");
+    expect(tokens.size).toBe(1);
+    expect(restore(p, tokens)).toBe("Hello {{name}}!");
+  });
+
+  it("round-trips multiple i18next placeholders in one string", () => {
+    const src = "Welcome {{user}}, you have {{count}} messages.";
+    const { protected: p, tokens } = protect(src);
+    expect(tokens.size).toBe(2);
+    expect(p).not.toMatch(/\{\{/);
+    expect(restore(p, tokens)).toBe(src);
+  });
+
+  it("round-trips ES template ${var} placeholders", () => {
+    const src = "Path: ${cwd}/file.txt";
+    const { protected: p, tokens } = protect(src);
+    expect(tokens.size).toBe(1);
+    expect(restore(p, tokens)).toBe(src);
+  });
+
+  it("round-trips .NET composite formatting {0}, {0:N2}, and named slots", () => {
+    const src = "{0} of {1:N2} (user={name})";
+    const { protected: p, tokens } = protect(src);
+    expect(tokens.size).toBe(3);
+    expect(p).not.toContain("{0}");
+    expect(p).not.toContain("{1:N2}");
+    expect(p).not.toContain("{name}");
+    expect(restore(p, tokens)).toBe(src);
+  });
+
+  it("round-trips printf positional and plain specifiers", () => {
+    const src = "%1$s spent %.2f on %s";
+    const { protected: p, tokens } = protect(src);
+    expect(tokens.size).toBe(3);
+    expect(restore(p, tokens)).toBe(src);
+  });
+
+  it("round-trips HTML entities", () => {
+    const src = "Hello&nbsp;world&amp;more";
+    const { protected: p, tokens } = protect(src);
+    expect(tokens.size).toBe(2);
+    expect(restore(p, tokens)).toBe(src);
+  });
+
+  it("survives translator-shaped reordering (placeholder still restored when surrounding text changes)", () => {
+    const src = "Hello {{name}}, you have {{count}} new items!";
+    const { protected: p, tokens } = protect(src);
+    const fauxTranslated = p
+      .replace("Hello", "Bonjour")
+      .replace("you have", "vous avez")
+      .replace("new items", "nouveaux éléments");
+    const restored = restore(fauxTranslated, tokens);
+    expect(restored).toContain("{{name}}");
+    expect(restored).toContain("{{count}}");
+    expect(restored).toBe(
+      "Bonjour {{name}}, vous avez {{count}} nouveaux éléments!",
+    );
+  });
+
+  it("handles empty input safely", () => {
+    const { protected: p, tokens } = protect("");
+    expect(p).toBe("");
+    expect(tokens.size).toBe(0);
+    expect(restore("", tokens)).toBe("");
+  });
+
+  it("ignores text with no placeholders", () => {
+    const src = "Just a plain sentence.";
+    const { protected: p, tokens } = protect(src);
+    expect(p).toBe(src);
+    expect(tokens.size).toBe(0);
+  });
+
+  it("uses unique sentinel tokens within a single protect() call", () => {
+    const src = "{{a}} {{b}} {{c}} {{d}}";
+    const { protected: p, tokens } = protect(src);
+    const matches = p.match(/RTKEEP\d{6}/g) ?? [];
+    expect(new Set(matches).size).toBe(matches.length);
+    expect(tokens.size).toBe(4);
+  });
+
+  it("accepts custom patterns", () => {
+    const src = "Token <<KEEP>> here";
+    const { protected: p, tokens } = protect(src, ["<<KEEP>>"]);
+    expect(p).not.toContain("<<KEEP>>");
+    expect(tokens.size).toBe(1);
+    expect(restore(p, tokens)).toBe(src);
+  });
+
+  it("silently ignores invalid custom regexes and still applies defaults", () => {
+    const src = "Hello {{name}}";
+    const { protected: p, tokens } = protect(src, ["[invalid("]);
+    expect(tokens.size).toBe(1);
+    expect(restore(p, tokens)).toBe(src);
+  });
+
+  it("restore() leaves unknown tokens untouched", () => {
+    expect(restore("Hello RTKEEP999999!", new Map())).toBe(
+      "Hello RTKEEP999999!",
+    );
+  });
+});

--- a/__tests__/helpers/retry.test.ts
+++ b/__tests__/helpers/retry.test.ts
@@ -1,0 +1,186 @@
+jest.mock("@actions/core", () => ({
+  warning: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+}));
+
+import {
+  isTransientStatus,
+  parseRetryAfter,
+  retryablePost,
+} from "../../src/helpers/retry";
+
+describe("retry.isTransientStatus", () => {
+  it.each([408, 425, 429, 500, 502, 503, 504, "429"])(
+    "marks %p as transient",
+    (status) => {
+      expect(isTransientStatus(status as number | string)).toBe(true);
+    },
+  );
+
+  it.each([200, 201, 301, 400, 401, 403, 404, 409, 422])(
+    "does NOT mark %p as transient",
+    (status) => {
+      expect(isTransientStatus(status)).toBe(false);
+    },
+  );
+
+  it("returns false for unparseable input", () => {
+    expect(isTransientStatus("not-a-number")).toBe(false);
+  });
+});
+
+describe("retry.parseRetryAfter", () => {
+  it("parses delta-seconds form", () => {
+    expect(parseRetryAfter({ "retry-after": "3" })).toBe(3000);
+    expect(parseRetryAfter({ "Retry-After": "1.5" })).toBe(1500);
+    expect(parseRetryAfter({ "retry-after": "0" })).toBe(0);
+  });
+
+  it("parses HTTP-date form relative to `now`", () => {
+    const now = Date.UTC(2024, 0, 1, 12, 0, 0);
+    const sixtySecondsLater = new Date(now + 60_000).toUTCString();
+    expect(
+      parseRetryAfter({ "retry-after": sixtySecondsLater }, now),
+    ).toBeGreaterThanOrEqual(59_000);
+    expect(
+      parseRetryAfter({ "retry-after": sixtySecondsLater }, now),
+    ).toBeLessThanOrEqual(60_000);
+  });
+
+  it("clamps a past HTTP-date to 0", () => {
+    const now = Date.UTC(2024, 0, 2);
+    const past = new Date(now - 60_000).toUTCString();
+    expect(parseRetryAfter({ "retry-after": past }, now)).toBe(0);
+  });
+
+  it("returns undefined when header missing", () => {
+    expect(parseRetryAfter(undefined)).toBeUndefined();
+    expect(parseRetryAfter({})).toBeUndefined();
+  });
+
+  it("returns undefined for unparseable values", () => {
+    expect(parseRetryAfter({ "retry-after": "soon" })).toBeUndefined();
+    expect(parseRetryAfter({ "retry-after": "" })).toBeUndefined();
+  });
+
+  it("handles array-form headers (takes the first value)", () => {
+    expect(parseRetryAfter({ "retry-after": ["7"] })).toBe(7000);
+  });
+});
+
+describe("retry.retryablePost", () => {
+  it("returns the first response when not transient", async () => {
+    const fn = jest.fn().mockResolvedValue({ status: 200 });
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+    const result = await retryablePost(
+      fn,
+      (r) => Number(r.status) >= 500,
+      undefined,
+      sleepFn,
+    );
+    expect(result.status).toBe(200);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it("retries on transient response and returns the eventual success", async () => {
+    const fn = jest
+      .fn()
+      .mockResolvedValueOnce({
+        status: 429,
+        headers: { "retry-after": "1" },
+      })
+      .mockResolvedValueOnce({ status: 200 });
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+
+    const result = await retryablePost(
+      fn,
+      (r) => Number(r.status) === 429 || Number(r.status) >= 500,
+      { maxRetries: 3, retryBackoffMs: 5000 },
+      sleepFn,
+    );
+
+    expect(result.status).toBe(200);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+    // Retry-After of 1s should be honored exactly.
+    expect(sleepFn.mock.calls[0][0]).toBe(1000);
+  });
+
+  it("falls back to exponential backoff when no Retry-After is set", async () => {
+    const fn = jest
+      .fn()
+      .mockResolvedValueOnce({ status: 503 })
+      .mockResolvedValueOnce({ status: 200 });
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+
+    await retryablePost(
+      fn,
+      (r) => Number(r.status) >= 500,
+      { maxRetries: 5, retryBackoffMs: 30_000 },
+      sleepFn,
+    );
+
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+    // 2^0 * 500 +/- 250ms jitter
+    const ms = sleepFn.mock.calls[0][0];
+    expect(ms).toBeGreaterThanOrEqual(250);
+    expect(ms).toBeLessThanOrEqual(750);
+  });
+
+  it("caps each backoff sleep at retryBackoffMs", async () => {
+    const fn = jest
+      .fn()
+      .mockResolvedValueOnce({
+        status: 429,
+        headers: { "retry-after": "9999" },
+      })
+      .mockResolvedValueOnce({ status: 200 });
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+
+    await retryablePost(
+      fn,
+      (r) => Number(r.status) === 429,
+      { maxRetries: 5, retryBackoffMs: 250 },
+      sleepFn,
+    );
+
+    expect(sleepFn).toHaveBeenCalledWith(250);
+  });
+
+  it("gives up after maxRetries and returns the final transient response", async () => {
+    const transient = { status: 429, headers: { "retry-after": "0" } };
+    const fn = jest.fn().mockResolvedValue(transient);
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+
+    const result = await retryablePost(
+      fn,
+      (r) => Number(r.status) === 429,
+      { maxRetries: 2 },
+      sleepFn,
+    );
+
+    expect(result).toBe(transient);
+    // Initial call + 2 retries.
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry when maxRetries is 0", async () => {
+    const transient = { status: 503 };
+    const fn = jest.fn().mockResolvedValue(transient);
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+
+    const result = await retryablePost(
+      fn,
+      (r) => Number(r.status) >= 500,
+      { maxRetries: 0 },
+      sleepFn,
+    );
+
+    expect(result).toBe(transient);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,21 @@ inputs:
   allowFallback:
     description: "When 'false', Translator returns an error instead of falling back to the general system if the chosen 'categoryId' has no deployment for a target locale. Defaults to the Translator default (true) when unset."
     required: false
+  noTranslatePatterns:
+    description: "Optional newline-separated glob patterns matched against parser key paths (resx 'name', po 'msgid', xliff unit 'id', '[--]'-joined paths for json, raw key for ini/restext). Matching keys are kept verbatim and never sent to Translator."
+    required: false
+  protectPlaceholders:
+    description: "When 'true' (default), wrap '{{name}}', '{0}', '%s', '${var}', etc. in stable sentinels so Translator does not rearrange or translate them. Set to 'false' only if your source contains literal placeholder-like sequences."
+    required: false
+  customPlaceholderPatterns:
+    description: "Optional newline-separated regex patterns appended to the placeholder protector. Each pattern is compiled with the global flag if it does not start with a literal '/'. Invalid patterns are skipped."
+    required: false
+  maxRetries:
+    description: "Number of additional attempts on transient Translator failures (HTTP 408, 425, 429, 500, 502, 503, 504). Total HTTP calls per request = 1 + maxRetries. Defaults to 5."
+    required: false
+  retryBackoffMs:
+    description: "Cap (ms) on any single backoff sleep between retries. Translator's 'Retry-After' header is honored exactly when present; otherwise a jittered exponential sleep is used, capped at this value. Defaults to 30000."
+    required: false
   dryRun:
     description: "When 'true', perform translations and emit summary outputs but do not write files."
     required: false

--- a/dist/resource-translator/index.js
+++ b/dist/resource-translator/index.js
@@ -21449,7 +21449,7 @@ var require_core = __commonJS({
     exports2.isDebug = isDebug;
     exports2.debug = debug7;
     exports2.error = error;
-    exports2.warning = warning5;
+    exports2.warning = warning6;
     exports2.notice = notice;
     exports2.info = info2;
     exports2.startGroup = startGroup;
@@ -21542,7 +21542,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     function error(message, properties = {}) {
       (0, command_1.issueCommand)("error", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
-    function warning5(message, properties = {}) {
+    function warning6(message, properties = {}) {
       (0, command_1.issueCommand)("warning", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
     function notice(message, properties = {}) {
@@ -29502,10 +29502,10 @@ function getValues(context4, operator, key, modifier) {
 }
 function parseUrl(template) {
   return {
-    expand: expand.bind(null, template)
+    expand: expand2.bind(null, template)
   };
 }
-function expand(template, context4) {
+function expand2(template, context4) {
   var operators = ["+", "#", ".", "/", ";", "?", "&"];
   template = template.replace(
     /\{([^\{\}]+)\}|([^\{\}]+)/g,
@@ -30217,12 +30217,12 @@ async function hook(token, request2, route, parameters) {
   endpoint2.headers.authorization = withAuthorizationPrefix(token);
   return request2(endpoint2);
 }
-var b64url, sep, jwtRE, isJWT, createTokenAuth;
+var b64url, sep2, jwtRE, isJWT, createTokenAuth;
 var init_dist_bundle4 = __esm({
   "node_modules/@octokit/auth-token/dist-bundle/index.js"() {
     b64url = "(?:[a-zA-Z0-9_-]+)";
-    sep = "\\.";
-    jwtRE = new RegExp(`^${b64url}${sep}${b64url}${sep}${b64url}$`);
+    sep2 = "\\.";
+    jwtRE = new RegExp(`^${b64url}${sep2}${b64url}${sep2}${b64url}$`);
     isJWT = jwtRE.test.bind(jwtRE);
     createTokenAuth = function createTokenAuth2(token) {
       if (!token) {
@@ -35457,7 +35457,7 @@ var require_glob = __commonJS({
 });
 
 // src/index.ts
-var import_core10 = __toESM(require_core());
+var import_core11 = __toESM(require_core());
 
 // src/action/get-inputs.ts
 var import_core2 = __toESM(require_core());
@@ -38113,6 +38113,12 @@ var normalizeRepoConfig = (raw) => {
     }
     return void 0;
   };
+  const nonNegativeInt = (value) => {
+    if (value === void 0 || value === null || value === "") return void 0;
+    const n = typeof value === "number" ? value : Number.parseInt(String(value), 10);
+    if (!Number.isFinite(n) || n < 0) return void 0;
+    return n;
+  };
   return {
     sourceLocale: typeof raw.sourceLocale === "string" ? raw.sourceLocale : void 0,
     toLocales: stringList(raw.toLocales),
@@ -38130,7 +38136,12 @@ var normalizeRepoConfig = (raw) => {
       raw.profanityMarker,
       PROFANITY_MARKERS
     ),
-    allowFallback: booleanOrUndefined(raw.allowFallback)
+    allowFallback: booleanOrUndefined(raw.allowFallback),
+    noTranslatePatterns: stringList(raw.noTranslatePatterns),
+    protectPlaceholders: booleanOrUndefined(raw.protectPlaceholders),
+    customPlaceholderPatterns: stringList(raw.customPlaceholderPatterns),
+    maxRetries: nonNegativeInt(raw.maxRetries),
+    retryBackoffMs: nonNegativeInt(raw.retryBackoffMs)
   };
 };
 var mergeInputsAndConfig = (inputs, config) => {
@@ -38146,7 +38157,12 @@ var mergeInputsAndConfig = (inputs, config) => {
     "textType",
     "profanityAction",
     "profanityMarker",
-    "allowFallback"
+    "allowFallback",
+    "noTranslatePatterns",
+    "protectPlaceholders",
+    "customPlaceholderPatterns",
+    "maxRetries",
+    "retryBackoffMs"
   ];
   for (const key of keys) {
     if (merged[key] === void 0 || isEmpty(merged[key])) {
@@ -38190,6 +38206,11 @@ var getInputs = () => {
       PROFANITY_MARKERS
     ),
     allowFallback: getOptionalBooleanOrUndefined("allowFallback"),
+    noTranslatePatterns: getMultilineList("noTranslatePatterns"),
+    protectPlaceholders: getOptionalBooleanOrUndefined("protectPlaceholders"),
+    customPlaceholderPatterns: getMultilineList("customPlaceholderPatterns"),
+    maxRetries: getOptionalInt("maxRetries"),
+    retryBackoffMs: getOptionalInt("retryBackoffMs"),
     dryRun: getOptionalBoolean("dryRun", false),
     failOnError: getOptionalBoolean("failOnError", true)
   };
@@ -38266,6 +38287,17 @@ var getMultilineList = (name) => {
   const list = value.split(/\r?\n/).map((v) => v.trim()).filter(Boolean);
   return list.length ? list : void 0;
 };
+var getOptionalInt = (name) => {
+  const raw = (0, import_core2.getInput)(name)?.trim();
+  if (!raw) return void 0;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(
+      `Input '${name}' must be a non-negative integer. Got: '${raw}'.`
+    );
+  }
+  return n;
+};
 var getQuestionableArray = (inputName) => {
   const value = (0, import_core2.getInput)(inputName);
   if (value) {
@@ -38279,8 +38311,1810 @@ var getQuestionableArray = (inputName) => {
 };
 
 // src/resource-translator.ts
-var import_core9 = __toESM(require_core());
+var import_core10 = __toESM(require_core());
 var import_fs2 = require("fs");
+
+// node_modules/brace-expansion/node_modules/balanced-match/dist/esm/index.js
+var balanced = (a, b, str2) => {
+  const ma = a instanceof RegExp ? maybeMatch(a, str2) : a;
+  const mb = b instanceof RegExp ? maybeMatch(b, str2) : b;
+  const r = ma !== null && mb != null && range(ma, mb, str2);
+  return r && {
+    start: r[0],
+    end: r[1],
+    pre: str2.slice(0, r[0]),
+    body: str2.slice(r[0] + ma.length, r[1]),
+    post: str2.slice(r[1] + mb.length)
+  };
+};
+var maybeMatch = (reg, str2) => {
+  const m = str2.match(reg);
+  return m ? m[0] : null;
+};
+var range = (a, b, str2) => {
+  let begs, beg, left, right = void 0, result;
+  let ai = str2.indexOf(a);
+  let bi = str2.indexOf(b, ai + 1);
+  let i = ai;
+  if (ai >= 0 && bi > 0) {
+    if (a === b) {
+      return [ai, bi];
+    }
+    begs = [];
+    left = str2.length;
+    while (i >= 0 && !result) {
+      if (i === ai) {
+        begs.push(i);
+        ai = str2.indexOf(a, i + 1);
+      } else if (begs.length === 1) {
+        const r = begs.pop();
+        if (r !== void 0)
+          result = [r, bi];
+      } else {
+        beg = begs.pop();
+        if (beg !== void 0 && beg < left) {
+          left = beg;
+          right = bi;
+        }
+        bi = str2.indexOf(b, i + 1);
+      }
+      i = ai < bi && ai >= 0 ? ai : bi;
+    }
+    if (begs.length && right !== void 0) {
+      result = [left, right];
+    }
+  }
+  return result;
+};
+
+// node_modules/brace-expansion/dist/esm/index.js
+var escSlash = "\0SLASH" + Math.random() + "\0";
+var escOpen = "\0OPEN" + Math.random() + "\0";
+var escClose = "\0CLOSE" + Math.random() + "\0";
+var escComma = "\0COMMA" + Math.random() + "\0";
+var escPeriod = "\0PERIOD" + Math.random() + "\0";
+var escSlashPattern = new RegExp(escSlash, "g");
+var escOpenPattern = new RegExp(escOpen, "g");
+var escClosePattern = new RegExp(escClose, "g");
+var escCommaPattern = new RegExp(escComma, "g");
+var escPeriodPattern = new RegExp(escPeriod, "g");
+var slashPattern = /\\\\/g;
+var openPattern = /\\{/g;
+var closePattern = /\\}/g;
+var commaPattern = /\\,/g;
+var periodPattern = /\\\./g;
+var EXPANSION_MAX = 1e5;
+function numeric(str2) {
+  return !isNaN(str2) ? parseInt(str2, 10) : str2.charCodeAt(0);
+}
+function escapeBraces(str2) {
+  return str2.replace(slashPattern, escSlash).replace(openPattern, escOpen).replace(closePattern, escClose).replace(commaPattern, escComma).replace(periodPattern, escPeriod);
+}
+function unescapeBraces(str2) {
+  return str2.replace(escSlashPattern, "\\").replace(escOpenPattern, "{").replace(escClosePattern, "}").replace(escCommaPattern, ",").replace(escPeriodPattern, ".");
+}
+function parseCommaParts(str2) {
+  if (!str2) {
+    return [""];
+  }
+  const parts = [];
+  const m = balanced("{", "}", str2);
+  if (!m) {
+    return str2.split(",");
+  }
+  const { pre, body, post } = m;
+  const p = pre.split(",");
+  p[p.length - 1] += "{" + body + "}";
+  const postParts = parseCommaParts(post);
+  if (post.length) {
+    ;
+    p[p.length - 1] += postParts.shift();
+    p.push.apply(p, postParts);
+  }
+  parts.push.apply(parts, p);
+  return parts;
+}
+function expand(str2, options = {}) {
+  if (!str2) {
+    return [];
+  }
+  const { max = EXPANSION_MAX } = options;
+  if (str2.slice(0, 2) === "{}") {
+    str2 = "\\{\\}" + str2.slice(2);
+  }
+  return expand_(escapeBraces(str2), max, true).map(unescapeBraces);
+}
+function embrace(str2) {
+  return "{" + str2 + "}";
+}
+function isPadded(el) {
+  return /^-?0\d/.test(el);
+}
+function lte(i, y) {
+  return i <= y;
+}
+function gte(i, y) {
+  return i >= y;
+}
+function expand_(str2, max, isTop) {
+  const expansions = [];
+  const m = balanced("{", "}", str2);
+  if (!m)
+    return [str2];
+  const pre = m.pre;
+  const post = m.post.length ? expand_(m.post, max, false) : [""];
+  if (/\$$/.test(m.pre)) {
+    for (let k = 0; k < post.length && k < max; k++) {
+      const expansion = pre + "{" + m.body + "}" + post[k];
+      expansions.push(expansion);
+    }
+  } else {
+    const isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body);
+    const isAlphaSequence = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(m.body);
+    const isSequence = isNumericSequence || isAlphaSequence;
+    const isOptions = m.body.indexOf(",") >= 0;
+    if (!isSequence && !isOptions) {
+      if (m.post.match(/,(?!,).*\}/)) {
+        str2 = m.pre + "{" + m.body + escClose + m.post;
+        return expand_(str2, max, true);
+      }
+      return [str2];
+    }
+    let n;
+    if (isSequence) {
+      n = m.body.split(/\.\./);
+    } else {
+      n = parseCommaParts(m.body);
+      if (n.length === 1 && n[0] !== void 0) {
+        n = expand_(n[0], max, false).map(embrace);
+        if (n.length === 1) {
+          return post.map((p) => m.pre + n[0] + p);
+        }
+      }
+    }
+    let N;
+    if (isSequence && n[0] !== void 0 && n[1] !== void 0) {
+      const x = numeric(n[0]);
+      const y = numeric(n[1]);
+      const width = Math.max(n[0].length, n[1].length);
+      let incr = n.length === 3 && n[2] !== void 0 ? Math.max(Math.abs(numeric(n[2])), 1) : 1;
+      let test = lte;
+      const reverse = y < x;
+      if (reverse) {
+        incr *= -1;
+        test = gte;
+      }
+      const pad = n.some(isPadded);
+      N = [];
+      for (let i = x; test(i, y); i += incr) {
+        let c;
+        if (isAlphaSequence) {
+          c = String.fromCharCode(i);
+          if (c === "\\") {
+            c = "";
+          }
+        } else {
+          c = String(i);
+          if (pad) {
+            const need = width - c.length;
+            if (need > 0) {
+              const z = new Array(need + 1).join("0");
+              if (i < 0) {
+                c = "-" + z + c.slice(1);
+              } else {
+                c = z + c;
+              }
+            }
+          }
+        }
+        N.push(c);
+      }
+    } else {
+      N = [];
+      for (let j = 0; j < n.length; j++) {
+        N.push.apply(N, expand_(n[j], max, false));
+      }
+    }
+    for (let j = 0; j < N.length; j++) {
+      for (let k = 0; k < post.length && expansions.length < max; k++) {
+        const expansion = pre + N[j] + post[k];
+        if (!isTop || isSequence || expansion) {
+          expansions.push(expansion);
+        }
+      }
+    }
+  }
+  return expansions;
+}
+
+// node_modules/minimatch/dist/esm/assert-valid-pattern.js
+var MAX_PATTERN_LENGTH = 1024 * 64;
+var assertValidPattern = (pattern) => {
+  if (typeof pattern !== "string") {
+    throw new TypeError("invalid pattern");
+  }
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    throw new TypeError("pattern is too long");
+  }
+};
+
+// node_modules/minimatch/dist/esm/brace-expressions.js
+var posixClasses = {
+  "[:alnum:]": ["\\p{L}\\p{Nl}\\p{Nd}", true],
+  "[:alpha:]": ["\\p{L}\\p{Nl}", true],
+  "[:ascii:]": ["\\x00-\\x7f", false],
+  "[:blank:]": ["\\p{Zs}\\t", true],
+  "[:cntrl:]": ["\\p{Cc}", true],
+  "[:digit:]": ["\\p{Nd}", true],
+  "[:graph:]": ["\\p{Z}\\p{C}", true, true],
+  "[:lower:]": ["\\p{Ll}", true],
+  "[:print:]": ["\\p{C}", true],
+  "[:punct:]": ["\\p{P}", true],
+  "[:space:]": ["\\p{Z}\\t\\r\\n\\v\\f", true],
+  "[:upper:]": ["\\p{Lu}", true],
+  "[:word:]": ["\\p{L}\\p{Nl}\\p{Nd}\\p{Pc}", true],
+  "[:xdigit:]": ["A-Fa-f0-9", false]
+};
+var braceEscape = (s) => s.replace(/[[\]\\-]/g, "\\$&");
+var regexpEscape = (s) => s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+var rangesToString = (ranges) => ranges.join("");
+var parseClass = (glob, position) => {
+  const pos = position;
+  if (glob.charAt(pos) !== "[") {
+    throw new Error("not in a brace expression");
+  }
+  const ranges = [];
+  const negs = [];
+  let i = pos + 1;
+  let sawStart = false;
+  let uflag = false;
+  let escaping = false;
+  let negate = false;
+  let endPos = pos;
+  let rangeStart = "";
+  WHILE: while (i < glob.length) {
+    const c = glob.charAt(i);
+    if ((c === "!" || c === "^") && i === pos + 1) {
+      negate = true;
+      i++;
+      continue;
+    }
+    if (c === "]" && sawStart && !escaping) {
+      endPos = i + 1;
+      break;
+    }
+    sawStart = true;
+    if (c === "\\") {
+      if (!escaping) {
+        escaping = true;
+        i++;
+        continue;
+      }
+    }
+    if (c === "[" && !escaping) {
+      for (const [cls, [unip, u, neg]] of Object.entries(posixClasses)) {
+        if (glob.startsWith(cls, i)) {
+          if (rangeStart) {
+            return ["$.", false, glob.length - pos, true];
+          }
+          i += cls.length;
+          if (neg)
+            negs.push(unip);
+          else
+            ranges.push(unip);
+          uflag = uflag || u;
+          continue WHILE;
+        }
+      }
+    }
+    escaping = false;
+    if (rangeStart) {
+      if (c > rangeStart) {
+        ranges.push(braceEscape(rangeStart) + "-" + braceEscape(c));
+      } else if (c === rangeStart) {
+        ranges.push(braceEscape(c));
+      }
+      rangeStart = "";
+      i++;
+      continue;
+    }
+    if (glob.startsWith("-]", i + 1)) {
+      ranges.push(braceEscape(c + "-"));
+      i += 2;
+      continue;
+    }
+    if (glob.startsWith("-", i + 1)) {
+      rangeStart = c;
+      i += 2;
+      continue;
+    }
+    ranges.push(braceEscape(c));
+    i++;
+  }
+  if (endPos < i) {
+    return ["", false, 0, false];
+  }
+  if (!ranges.length && !negs.length) {
+    return ["$.", false, glob.length - pos, true];
+  }
+  if (negs.length === 0 && ranges.length === 1 && /^\\?.$/.test(ranges[0]) && !negate) {
+    const r = ranges[0].length === 2 ? ranges[0].slice(-1) : ranges[0];
+    return [regexpEscape(r), false, endPos - pos, false];
+  }
+  const sranges = "[" + (negate ? "^" : "") + rangesToString(ranges) + "]";
+  const snegs = "[" + (negate ? "" : "^") + rangesToString(negs) + "]";
+  const comb = ranges.length && negs.length ? "(" + sranges + "|" + snegs + ")" : ranges.length ? sranges : snegs;
+  return [comb, uflag, endPos - pos, true];
+};
+
+// node_modules/minimatch/dist/esm/unescape.js
+var unescape = (s, { windowsPathsNoEscape = false, magicalBraces = true } = {}) => {
+  if (magicalBraces) {
+    return windowsPathsNoEscape ? s.replace(/\[([^/\\])\]/g, "$1") : s.replace(/((?!\\).|^)\[([^/\\])\]/g, "$1$2").replace(/\\([^/])/g, "$1");
+  }
+  return windowsPathsNoEscape ? s.replace(/\[([^/\\{}])\]/g, "$1") : s.replace(/((?!\\).|^)\[([^/\\{}])\]/g, "$1$2").replace(/\\([^/{}])/g, "$1");
+};
+
+// node_modules/minimatch/dist/esm/ast.js
+var _a;
+var types = /* @__PURE__ */ new Set(["!", "?", "+", "*", "@"]);
+var isExtglobType = (c) => types.has(c);
+var isExtglobAST = (c) => isExtglobType(c.type);
+var adoptionMap = /* @__PURE__ */ new Map([
+  ["!", ["@"]],
+  ["?", ["?", "@"]],
+  ["@", ["@"]],
+  ["*", ["*", "+", "?", "@"]],
+  ["+", ["+", "@"]]
+]);
+var adoptionWithSpaceMap = /* @__PURE__ */ new Map([
+  ["!", ["?"]],
+  ["@", ["?"]],
+  ["+", ["?", "*"]]
+]);
+var adoptionAnyMap = /* @__PURE__ */ new Map([
+  ["!", ["?", "@"]],
+  ["?", ["?", "@"]],
+  ["@", ["?", "@"]],
+  ["*", ["*", "+", "?", "@"]],
+  ["+", ["+", "@", "?", "*"]]
+]);
+var usurpMap = /* @__PURE__ */ new Map([
+  ["!", /* @__PURE__ */ new Map([["!", "@"]])],
+  [
+    "?",
+    /* @__PURE__ */ new Map([
+      ["*", "*"],
+      ["+", "*"]
+    ])
+  ],
+  [
+    "@",
+    /* @__PURE__ */ new Map([
+      ["!", "!"],
+      ["?", "?"],
+      ["@", "@"],
+      ["*", "*"],
+      ["+", "+"]
+    ])
+  ],
+  [
+    "+",
+    /* @__PURE__ */ new Map([
+      ["?", "*"],
+      ["*", "*"]
+    ])
+  ]
+]);
+var startNoTraversal = "(?!(?:^|/)\\.\\.?(?:$|/))";
+var startNoDot = "(?!\\.)";
+var addPatternStart = /* @__PURE__ */ new Set(["[", "."]);
+var justDots = /* @__PURE__ */ new Set(["..", "."]);
+var reSpecials = new Set("().*{}+?[]^$\\!");
+var regExpEscape = (s) => s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+var qmark = "[^/]";
+var star = qmark + "*?";
+var starNoEmpty = qmark + "+?";
+var ID = 0;
+var AST = class {
+  type;
+  #root;
+  #hasMagic;
+  #uflag = false;
+  #parts = [];
+  #parent;
+  #parentIndex;
+  #negs;
+  #filledNegs = false;
+  #options;
+  #toString;
+  // set to true if it's an extglob with no children
+  // (which really means one child of '')
+  #emptyExt = false;
+  id = ++ID;
+  get depth() {
+    return (this.#parent?.depth ?? -1) + 1;
+  }
+  [/* @__PURE__ */ Symbol.for("nodejs.util.inspect.custom")]() {
+    return {
+      "@@type": "AST",
+      id: this.id,
+      type: this.type,
+      root: this.#root.id,
+      parent: this.#parent?.id,
+      depth: this.depth,
+      partsLength: this.#parts.length,
+      parts: this.#parts
+    };
+  }
+  constructor(type2, parent, options = {}) {
+    this.type = type2;
+    if (type2)
+      this.#hasMagic = true;
+    this.#parent = parent;
+    this.#root = this.#parent ? this.#parent.#root : this;
+    this.#options = this.#root === this ? options : this.#root.#options;
+    this.#negs = this.#root === this ? [] : this.#root.#negs;
+    if (type2 === "!" && !this.#root.#filledNegs)
+      this.#negs.push(this);
+    this.#parentIndex = this.#parent ? this.#parent.#parts.length : 0;
+  }
+  get hasMagic() {
+    if (this.#hasMagic !== void 0)
+      return this.#hasMagic;
+    for (const p of this.#parts) {
+      if (typeof p === "string")
+        continue;
+      if (p.type || p.hasMagic)
+        return this.#hasMagic = true;
+    }
+    return this.#hasMagic;
+  }
+  // reconstructs the pattern
+  toString() {
+    return this.#toString !== void 0 ? this.#toString : !this.type ? this.#toString = this.#parts.map((p) => String(p)).join("") : this.#toString = this.type + "(" + this.#parts.map((p) => String(p)).join("|") + ")";
+  }
+  #fillNegs() {
+    if (this !== this.#root)
+      throw new Error("should only call on root");
+    if (this.#filledNegs)
+      return this;
+    this.toString();
+    this.#filledNegs = true;
+    let n;
+    while (n = this.#negs.pop()) {
+      if (n.type !== "!")
+        continue;
+      let p = n;
+      let pp = p.#parent;
+      while (pp) {
+        for (let i = p.#parentIndex + 1; !pp.type && i < pp.#parts.length; i++) {
+          for (const part of n.#parts) {
+            if (typeof part === "string") {
+              throw new Error("string part in extglob AST??");
+            }
+            part.copyIn(pp.#parts[i]);
+          }
+        }
+        p = pp;
+        pp = p.#parent;
+      }
+    }
+    return this;
+  }
+  push(...parts) {
+    for (const p of parts) {
+      if (p === "")
+        continue;
+      if (typeof p !== "string" && !(p instanceof _a && p.#parent === this)) {
+        throw new Error("invalid part: " + p);
+      }
+      this.#parts.push(p);
+    }
+  }
+  toJSON() {
+    const ret = this.type === null ? this.#parts.slice().map((p) => typeof p === "string" ? p : p.toJSON()) : [this.type, ...this.#parts.map((p) => p.toJSON())];
+    if (this.isStart() && !this.type)
+      ret.unshift([]);
+    if (this.isEnd() && (this === this.#root || this.#root.#filledNegs && this.#parent?.type === "!")) {
+      ret.push({});
+    }
+    return ret;
+  }
+  isStart() {
+    if (this.#root === this)
+      return true;
+    if (!this.#parent?.isStart())
+      return false;
+    if (this.#parentIndex === 0)
+      return true;
+    const p = this.#parent;
+    for (let i = 0; i < this.#parentIndex; i++) {
+      const pp = p.#parts[i];
+      if (!(pp instanceof _a && pp.type === "!")) {
+        return false;
+      }
+    }
+    return true;
+  }
+  isEnd() {
+    if (this.#root === this)
+      return true;
+    if (this.#parent?.type === "!")
+      return true;
+    if (!this.#parent?.isEnd())
+      return false;
+    if (!this.type)
+      return this.#parent?.isEnd();
+    const pl = this.#parent ? this.#parent.#parts.length : 0;
+    return this.#parentIndex === pl - 1;
+  }
+  copyIn(part) {
+    if (typeof part === "string")
+      this.push(part);
+    else
+      this.push(part.clone(this));
+  }
+  clone(parent) {
+    const c = new _a(this.type, parent);
+    for (const p of this.#parts) {
+      c.copyIn(p);
+    }
+    return c;
+  }
+  static #parseAST(str2, ast, pos, opt, extDepth) {
+    const maxDepth = opt.maxExtglobRecursion ?? 2;
+    let escaping = false;
+    let inBrace = false;
+    let braceStart = -1;
+    let braceNeg = false;
+    if (ast.type === null) {
+      let i2 = pos;
+      let acc2 = "";
+      while (i2 < str2.length) {
+        const c = str2.charAt(i2++);
+        if (escaping || c === "\\") {
+          escaping = !escaping;
+          acc2 += c;
+          continue;
+        }
+        if (inBrace) {
+          if (i2 === braceStart + 1) {
+            if (c === "^" || c === "!") {
+              braceNeg = true;
+            }
+          } else if (c === "]" && !(i2 === braceStart + 2 && braceNeg)) {
+            inBrace = false;
+          }
+          acc2 += c;
+          continue;
+        } else if (c === "[") {
+          inBrace = true;
+          braceStart = i2;
+          braceNeg = false;
+          acc2 += c;
+          continue;
+        }
+        const doRecurse = !opt.noext && isExtglobType(c) && str2.charAt(i2) === "(" && extDepth <= maxDepth;
+        if (doRecurse) {
+          ast.push(acc2);
+          acc2 = "";
+          const ext2 = new _a(c, ast);
+          i2 = _a.#parseAST(str2, ext2, i2, opt, extDepth + 1);
+          ast.push(ext2);
+          continue;
+        }
+        acc2 += c;
+      }
+      ast.push(acc2);
+      return i2;
+    }
+    let i = pos + 1;
+    let part = new _a(null, ast);
+    const parts = [];
+    let acc = "";
+    while (i < str2.length) {
+      const c = str2.charAt(i++);
+      if (escaping || c === "\\") {
+        escaping = !escaping;
+        acc += c;
+        continue;
+      }
+      if (inBrace) {
+        if (i === braceStart + 1) {
+          if (c === "^" || c === "!") {
+            braceNeg = true;
+          }
+        } else if (c === "]" && !(i === braceStart + 2 && braceNeg)) {
+          inBrace = false;
+        }
+        acc += c;
+        continue;
+      } else if (c === "[") {
+        inBrace = true;
+        braceStart = i;
+        braceNeg = false;
+        acc += c;
+        continue;
+      }
+      const doRecurse = !opt.noext && isExtglobType(c) && str2.charAt(i) === "(" && /* c8 ignore start - the maxDepth is sufficient here */
+      (extDepth <= maxDepth || ast && ast.#canAdoptType(c));
+      if (doRecurse) {
+        const depthAdd = ast && ast.#canAdoptType(c) ? 0 : 1;
+        part.push(acc);
+        acc = "";
+        const ext2 = new _a(c, part);
+        part.push(ext2);
+        i = _a.#parseAST(str2, ext2, i, opt, extDepth + depthAdd);
+        continue;
+      }
+      if (c === "|") {
+        part.push(acc);
+        acc = "";
+        parts.push(part);
+        part = new _a(null, ast);
+        continue;
+      }
+      if (c === ")") {
+        if (acc === "" && ast.#parts.length === 0) {
+          ast.#emptyExt = true;
+        }
+        part.push(acc);
+        acc = "";
+        ast.push(...parts, part);
+        return i;
+      }
+      acc += c;
+    }
+    ast.type = null;
+    ast.#hasMagic = void 0;
+    ast.#parts = [str2.substring(pos - 1)];
+    return i;
+  }
+  #canAdoptWithSpace(child) {
+    return this.#canAdopt(child, adoptionWithSpaceMap);
+  }
+  #canAdopt(child, map2 = adoptionMap) {
+    if (!child || typeof child !== "object" || child.type !== null || child.#parts.length !== 1 || this.type === null) {
+      return false;
+    }
+    const gc = child.#parts[0];
+    if (!gc || typeof gc !== "object" || gc.type === null) {
+      return false;
+    }
+    return this.#canAdoptType(gc.type, map2);
+  }
+  #canAdoptType(c, map2 = adoptionAnyMap) {
+    return !!map2.get(this.type)?.includes(c);
+  }
+  #adoptWithSpace(child, index) {
+    const gc = child.#parts[0];
+    const blank = new _a(null, gc, this.options);
+    blank.#parts.push("");
+    gc.push(blank);
+    this.#adopt(child, index);
+  }
+  #adopt(child, index) {
+    const gc = child.#parts[0];
+    this.#parts.splice(index, 1, ...gc.#parts);
+    for (const p of gc.#parts) {
+      if (typeof p === "object")
+        p.#parent = this;
+    }
+    this.#toString = void 0;
+  }
+  #canUsurpType(c) {
+    const m = usurpMap.get(this.type);
+    return !!m?.has(c);
+  }
+  #canUsurp(child) {
+    if (!child || typeof child !== "object" || child.type !== null || child.#parts.length !== 1 || this.type === null || this.#parts.length !== 1) {
+      return false;
+    }
+    const gc = child.#parts[0];
+    if (!gc || typeof gc !== "object" || gc.type === null) {
+      return false;
+    }
+    return this.#canUsurpType(gc.type);
+  }
+  #usurp(child) {
+    const m = usurpMap.get(this.type);
+    const gc = child.#parts[0];
+    const nt = m?.get(gc.type);
+    if (!nt)
+      return false;
+    this.#parts = gc.#parts;
+    for (const p of this.#parts) {
+      if (typeof p === "object") {
+        p.#parent = this;
+      }
+    }
+    this.type = nt;
+    this.#toString = void 0;
+    this.#emptyExt = false;
+  }
+  static fromGlob(pattern, options = {}) {
+    const ast = new _a(null, void 0, options);
+    _a.#parseAST(pattern, ast, 0, options, 0);
+    return ast;
+  }
+  // returns the regular expression if there's magic, or the unescaped
+  // string if not.
+  toMMPattern() {
+    if (this !== this.#root)
+      return this.#root.toMMPattern();
+    const glob = this.toString();
+    const [re, body, hasMagic, uflag] = this.toRegExpSource();
+    const anyMagic = hasMagic || this.#hasMagic || this.#options.nocase && !this.#options.nocaseMagicOnly && glob.toUpperCase() !== glob.toLowerCase();
+    if (!anyMagic) {
+      return body;
+    }
+    const flags = (this.#options.nocase ? "i" : "") + (uflag ? "u" : "");
+    return Object.assign(new RegExp(`^${re}$`, flags), {
+      _src: re,
+      _glob: glob
+    });
+  }
+  get options() {
+    return this.#options;
+  }
+  // returns the string match, the regexp source, whether there's magic
+  // in the regexp (so a regular expression is required) and whether or
+  // not the uflag is needed for the regular expression (for posix classes)
+  // TODO: instead of injecting the start/end at this point, just return
+  // the BODY of the regexp, along with the start/end portions suitable
+  // for binding the start/end in either a joined full-path makeRe context
+  // (where we bind to (^|/), or a standalone matchPart context (where
+  // we bind to ^, and not /).  Otherwise slashes get duped!
+  //
+  // In part-matching mode, the start is:
+  // - if not isStart: nothing
+  // - if traversal possible, but not allowed: ^(?!\.\.?$)
+  // - if dots allowed or not possible: ^
+  // - if dots possible and not allowed: ^(?!\.)
+  // end is:
+  // - if not isEnd(): nothing
+  // - else: $
+  //
+  // In full-path matching mode, we put the slash at the START of the
+  // pattern, so start is:
+  // - if first pattern: same as part-matching mode
+  // - if not isStart(): nothing
+  // - if traversal possible, but not allowed: /(?!\.\.?(?:$|/))
+  // - if dots allowed or not possible: /
+  // - if dots possible and not allowed: /(?!\.)
+  // end is:
+  // - if last pattern, same as part-matching mode
+  // - else nothing
+  //
+  // Always put the (?:$|/) on negated tails, though, because that has to be
+  // there to bind the end of the negated pattern portion, and it's easier to
+  // just stick it in now rather than try to inject it later in the middle of
+  // the pattern.
+  //
+  // We can just always return the same end, and leave it up to the caller
+  // to know whether it's going to be used joined or in parts.
+  // And, if the start is adjusted slightly, can do the same there:
+  // - if not isStart: nothing
+  // - if traversal possible, but not allowed: (?:/|^)(?!\.\.?$)
+  // - if dots allowed or not possible: (?:/|^)
+  // - if dots possible and not allowed: (?:/|^)(?!\.)
+  //
+  // But it's better to have a simpler binding without a conditional, for
+  // performance, so probably better to return both start options.
+  //
+  // Then the caller just ignores the end if it's not the first pattern,
+  // and the start always gets applied.
+  //
+  // But that's always going to be $ if it's the ending pattern, or nothing,
+  // so the caller can just attach $ at the end of the pattern when building.
+  //
+  // So the todo is:
+  // - better detect what kind of start is needed
+  // - return both flavors of starting pattern
+  // - attach $ at the end of the pattern when creating the actual RegExp
+  //
+  // Ah, but wait, no, that all only applies to the root when the first pattern
+  // is not an extglob. If the first pattern IS an extglob, then we need all
+  // that dot prevention biz to live in the extglob portions, because eg
+  // +(*|.x*) can match .xy but not .yx.
+  //
+  // So, return the two flavors if it's #root and the first child is not an
+  // AST, otherwise leave it to the child AST to handle it, and there,
+  // use the (?:^|/) style of start binding.
+  //
+  // Even simplified further:
+  // - Since the start for a join is eg /(?!\.) and the start for a part
+  // is ^(?!\.), we can just prepend (?!\.) to the pattern (either root
+  // or start or whatever) and prepend ^ or / at the Regexp construction.
+  toRegExpSource(allowDot) {
+    const dot = allowDot ?? !!this.#options.dot;
+    if (this.#root === this) {
+      this.#flatten();
+      this.#fillNegs();
+    }
+    if (!isExtglobAST(this)) {
+      const noEmpty = this.isStart() && this.isEnd() && !this.#parts.some((s) => typeof s !== "string");
+      const src = this.#parts.map((p) => {
+        const [re, _, hasMagic, uflag] = typeof p === "string" ? _a.#parseGlob(p, this.#hasMagic, noEmpty) : p.toRegExpSource(allowDot);
+        this.#hasMagic = this.#hasMagic || hasMagic;
+        this.#uflag = this.#uflag || uflag;
+        return re;
+      }).join("");
+      let start3 = "";
+      if (this.isStart()) {
+        if (typeof this.#parts[0] === "string") {
+          const dotTravAllowed = this.#parts.length === 1 && justDots.has(this.#parts[0]);
+          if (!dotTravAllowed) {
+            const aps = addPatternStart;
+            const needNoTrav = (
+              // dots are allowed, and the pattern starts with [ or .
+              dot && aps.has(src.charAt(0)) || // the pattern starts with \., and then [ or .
+              src.startsWith("\\.") && aps.has(src.charAt(2)) || // the pattern starts with \.\., and then [ or .
+              src.startsWith("\\.\\.") && aps.has(src.charAt(4))
+            );
+            const needNoDot = !dot && !allowDot && aps.has(src.charAt(0));
+            start3 = needNoTrav ? startNoTraversal : needNoDot ? startNoDot : "";
+          }
+        }
+      }
+      let end = "";
+      if (this.isEnd() && this.#root.#filledNegs && this.#parent?.type === "!") {
+        end = "(?:$|\\/)";
+      }
+      const final2 = start3 + src + end;
+      return [
+        final2,
+        unescape(src),
+        this.#hasMagic = !!this.#hasMagic,
+        this.#uflag
+      ];
+    }
+    const repeated = this.type === "*" || this.type === "+";
+    const start2 = this.type === "!" ? "(?:(?!(?:" : "(?:";
+    let body = this.#partsToRegExp(dot);
+    if (this.isStart() && this.isEnd() && !body && this.type !== "!") {
+      const s = this.toString();
+      const me = this;
+      me.#parts = [s];
+      me.type = null;
+      me.#hasMagic = void 0;
+      return [s, unescape(this.toString()), false, false];
+    }
+    let bodyDotAllowed = !repeated || allowDot || dot || !startNoDot ? "" : this.#partsToRegExp(true);
+    if (bodyDotAllowed === body) {
+      bodyDotAllowed = "";
+    }
+    if (bodyDotAllowed) {
+      body = `(?:${body})(?:${bodyDotAllowed})*?`;
+    }
+    let final = "";
+    if (this.type === "!" && this.#emptyExt) {
+      final = (this.isStart() && !dot ? startNoDot : "") + starNoEmpty;
+    } else {
+      const close = this.type === "!" ? (
+        // !() must match something,but !(x) can match ''
+        "))" + (this.isStart() && !dot && !allowDot ? startNoDot : "") + star + ")"
+      ) : this.type === "@" ? ")" : this.type === "?" ? ")?" : this.type === "+" && bodyDotAllowed ? ")" : this.type === "*" && bodyDotAllowed ? `)?` : `)${this.type}`;
+      final = start2 + body + close;
+    }
+    return [
+      final,
+      unescape(body),
+      this.#hasMagic = !!this.#hasMagic,
+      this.#uflag
+    ];
+  }
+  #flatten() {
+    if (!isExtglobAST(this)) {
+      for (const p of this.#parts) {
+        if (typeof p === "object") {
+          p.#flatten();
+        }
+      }
+    } else {
+      let iterations = 0;
+      let done = false;
+      do {
+        done = true;
+        for (let i = 0; i < this.#parts.length; i++) {
+          const c = this.#parts[i];
+          if (typeof c === "object") {
+            c.#flatten();
+            if (this.#canAdopt(c)) {
+              done = false;
+              this.#adopt(c, i);
+            } else if (this.#canAdoptWithSpace(c)) {
+              done = false;
+              this.#adoptWithSpace(c, i);
+            } else if (this.#canUsurp(c)) {
+              done = false;
+              this.#usurp(c);
+            }
+          }
+        }
+      } while (!done && ++iterations < 10);
+    }
+    this.#toString = void 0;
+  }
+  #partsToRegExp(dot) {
+    return this.#parts.map((p) => {
+      if (typeof p === "string") {
+        throw new Error("string type in extglob ast??");
+      }
+      const [re, _, _hasMagic, uflag] = p.toRegExpSource(dot);
+      this.#uflag = this.#uflag || uflag;
+      return re;
+    }).filter((p) => !(this.isStart() && this.isEnd()) || !!p).join("|");
+  }
+  static #parseGlob(glob, hasMagic, noEmpty = false) {
+    let escaping = false;
+    let re = "";
+    let uflag = false;
+    let inStar = false;
+    for (let i = 0; i < glob.length; i++) {
+      const c = glob.charAt(i);
+      if (escaping) {
+        escaping = false;
+        re += (reSpecials.has(c) ? "\\" : "") + c;
+        continue;
+      }
+      if (c === "*") {
+        if (inStar)
+          continue;
+        inStar = true;
+        re += noEmpty && /^[*]+$/.test(glob) ? starNoEmpty : star;
+        hasMagic = true;
+        continue;
+      } else {
+        inStar = false;
+      }
+      if (c === "\\") {
+        if (i === glob.length - 1) {
+          re += "\\\\";
+        } else {
+          escaping = true;
+        }
+        continue;
+      }
+      if (c === "[") {
+        const [src, needUflag, consumed, magic] = parseClass(glob, i);
+        if (consumed) {
+          re += src;
+          uflag = uflag || needUflag;
+          i += consumed - 1;
+          hasMagic = hasMagic || magic;
+          continue;
+        }
+      }
+      if (c === "?") {
+        re += qmark;
+        hasMagic = true;
+        continue;
+      }
+      re += regExpEscape(c);
+    }
+    return [re, unescape(glob), !!hasMagic, uflag];
+  }
+};
+_a = AST;
+
+// node_modules/minimatch/dist/esm/escape.js
+var escape = (s, { windowsPathsNoEscape = false, magicalBraces = false } = {}) => {
+  if (magicalBraces) {
+    return windowsPathsNoEscape ? s.replace(/[?*()[\]{}]/g, "[$&]") : s.replace(/[?*()[\]\\{}]/g, "\\$&");
+  }
+  return windowsPathsNoEscape ? s.replace(/[?*()[\]]/g, "[$&]") : s.replace(/[?*()[\]\\]/g, "\\$&");
+};
+
+// node_modules/minimatch/dist/esm/index.js
+var minimatch = (p, pattern, options = {}) => {
+  assertValidPattern(pattern);
+  if (!options.nocomment && pattern.charAt(0) === "#") {
+    return false;
+  }
+  return new Minimatch(pattern, options).match(p);
+};
+var starDotExtRE = /^\*+([^+@!?*[(]*)$/;
+var starDotExtTest = (ext2) => (f) => !f.startsWith(".") && f.endsWith(ext2);
+var starDotExtTestDot = (ext2) => (f) => f.endsWith(ext2);
+var starDotExtTestNocase = (ext2) => {
+  ext2 = ext2.toLowerCase();
+  return (f) => !f.startsWith(".") && f.toLowerCase().endsWith(ext2);
+};
+var starDotExtTestNocaseDot = (ext2) => {
+  ext2 = ext2.toLowerCase();
+  return (f) => f.toLowerCase().endsWith(ext2);
+};
+var starDotStarRE = /^\*+\.\*+$/;
+var starDotStarTest = (f) => !f.startsWith(".") && f.includes(".");
+var starDotStarTestDot = (f) => f !== "." && f !== ".." && f.includes(".");
+var dotStarRE = /^\.\*+$/;
+var dotStarTest = (f) => f !== "." && f !== ".." && f.startsWith(".");
+var starRE = /^\*+$/;
+var starTest = (f) => f.length !== 0 && !f.startsWith(".");
+var starTestDot = (f) => f.length !== 0 && f !== "." && f !== "..";
+var qmarksRE = /^\?+([^+@!?*[(]*)?$/;
+var qmarksTestNocase = ([$0, ext2 = ""]) => {
+  const noext = qmarksTestNoExt([$0]);
+  if (!ext2)
+    return noext;
+  ext2 = ext2.toLowerCase();
+  return (f) => noext(f) && f.toLowerCase().endsWith(ext2);
+};
+var qmarksTestNocaseDot = ([$0, ext2 = ""]) => {
+  const noext = qmarksTestNoExtDot([$0]);
+  if (!ext2)
+    return noext;
+  ext2 = ext2.toLowerCase();
+  return (f) => noext(f) && f.toLowerCase().endsWith(ext2);
+};
+var qmarksTestDot = ([$0, ext2 = ""]) => {
+  const noext = qmarksTestNoExtDot([$0]);
+  return !ext2 ? noext : (f) => noext(f) && f.endsWith(ext2);
+};
+var qmarksTest = ([$0, ext2 = ""]) => {
+  const noext = qmarksTestNoExt([$0]);
+  return !ext2 ? noext : (f) => noext(f) && f.endsWith(ext2);
+};
+var qmarksTestNoExt = ([$0]) => {
+  const len = $0.length;
+  return (f) => f.length === len && !f.startsWith(".");
+};
+var qmarksTestNoExtDot = ([$0]) => {
+  const len = $0.length;
+  return (f) => f.length === len && f !== "." && f !== "..";
+};
+var defaultPlatform = typeof process === "object" && process ? typeof process.env === "object" && process.env && process.env.__MINIMATCH_TESTING_PLATFORM__ || process.platform : "posix";
+var path = {
+  win32: { sep: "\\" },
+  posix: { sep: "/" }
+};
+var sep = defaultPlatform === "win32" ? path.win32.sep : path.posix.sep;
+minimatch.sep = sep;
+var GLOBSTAR = /* @__PURE__ */ Symbol("globstar **");
+minimatch.GLOBSTAR = GLOBSTAR;
+var qmark2 = "[^/]";
+var star2 = qmark2 + "*?";
+var twoStarDot = "(?:(?!(?:\\/|^)(?:\\.{1,2})($|\\/)).)*?";
+var twoStarNoDot = "(?:(?!(?:\\/|^)\\.).)*?";
+var filter = (pattern, options = {}) => (p) => minimatch(p, pattern, options);
+minimatch.filter = filter;
+var ext = (a, b = {}) => Object.assign({}, a, b);
+var defaults = (def) => {
+  if (!def || typeof def !== "object" || !Object.keys(def).length) {
+    return minimatch;
+  }
+  const orig = minimatch;
+  const m = (p, pattern, options = {}) => orig(p, pattern, ext(def, options));
+  return Object.assign(m, {
+    Minimatch: class Minimatch extends orig.Minimatch {
+      constructor(pattern, options = {}) {
+        super(pattern, ext(def, options));
+      }
+      static defaults(options) {
+        return orig.defaults(ext(def, options)).Minimatch;
+      }
+    },
+    AST: class AST extends orig.AST {
+      /* c8 ignore start */
+      constructor(type2, parent, options = {}) {
+        super(type2, parent, ext(def, options));
+      }
+      /* c8 ignore stop */
+      static fromGlob(pattern, options = {}) {
+        return orig.AST.fromGlob(pattern, ext(def, options));
+      }
+    },
+    unescape: (s, options = {}) => orig.unescape(s, ext(def, options)),
+    escape: (s, options = {}) => orig.escape(s, ext(def, options)),
+    filter: (pattern, options = {}) => orig.filter(pattern, ext(def, options)),
+    defaults: (options) => orig.defaults(ext(def, options)),
+    makeRe: (pattern, options = {}) => orig.makeRe(pattern, ext(def, options)),
+    braceExpand: (pattern, options = {}) => orig.braceExpand(pattern, ext(def, options)),
+    match: (list, pattern, options = {}) => orig.match(list, pattern, ext(def, options)),
+    sep: orig.sep,
+    GLOBSTAR
+  });
+};
+minimatch.defaults = defaults;
+var braceExpand = (pattern, options = {}) => {
+  assertValidPattern(pattern);
+  if (options.nobrace || !/\{(?:(?!\{).)*\}/.test(pattern)) {
+    return [pattern];
+  }
+  return expand(pattern, { max: options.braceExpandMax });
+};
+minimatch.braceExpand = braceExpand;
+var makeRe = (pattern, options = {}) => new Minimatch(pattern, options).makeRe();
+minimatch.makeRe = makeRe;
+var match = (list, pattern, options = {}) => {
+  const mm = new Minimatch(pattern, options);
+  list = list.filter((f) => mm.match(f));
+  if (mm.options.nonull && !list.length) {
+    list.push(pattern);
+  }
+  return list;
+};
+minimatch.match = match;
+var globMagic = /[?*]|[+@!]\(.*?\)|\[|\]/;
+var regExpEscape2 = (s) => s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+var Minimatch = class {
+  options;
+  set;
+  pattern;
+  windowsPathsNoEscape;
+  nonegate;
+  negate;
+  comment;
+  empty;
+  preserveMultipleSlashes;
+  partial;
+  globSet;
+  globParts;
+  nocase;
+  isWindows;
+  platform;
+  windowsNoMagicRoot;
+  maxGlobstarRecursion;
+  regexp;
+  constructor(pattern, options = {}) {
+    assertValidPattern(pattern);
+    options = options || {};
+    this.options = options;
+    this.maxGlobstarRecursion = options.maxGlobstarRecursion ?? 200;
+    this.pattern = pattern;
+    this.platform = options.platform || defaultPlatform;
+    this.isWindows = this.platform === "win32";
+    const awe = "allowWindowsEscape";
+    this.windowsPathsNoEscape = !!options.windowsPathsNoEscape || options[awe] === false;
+    if (this.windowsPathsNoEscape) {
+      this.pattern = this.pattern.replace(/\\/g, "/");
+    }
+    this.preserveMultipleSlashes = !!options.preserveMultipleSlashes;
+    this.regexp = null;
+    this.negate = false;
+    this.nonegate = !!options.nonegate;
+    this.comment = false;
+    this.empty = false;
+    this.partial = !!options.partial;
+    this.nocase = !!this.options.nocase;
+    this.windowsNoMagicRoot = options.windowsNoMagicRoot !== void 0 ? options.windowsNoMagicRoot : !!(this.isWindows && this.nocase);
+    this.globSet = [];
+    this.globParts = [];
+    this.set = [];
+    this.make();
+  }
+  hasMagic() {
+    if (this.options.magicalBraces && this.set.length > 1) {
+      return true;
+    }
+    for (const pattern of this.set) {
+      for (const part of pattern) {
+        if (typeof part !== "string")
+          return true;
+      }
+    }
+    return false;
+  }
+  debug(..._) {
+  }
+  make() {
+    const pattern = this.pattern;
+    const options = this.options;
+    if (!options.nocomment && pattern.charAt(0) === "#") {
+      this.comment = true;
+      return;
+    }
+    if (!pattern) {
+      this.empty = true;
+      return;
+    }
+    this.parseNegate();
+    this.globSet = [...new Set(this.braceExpand())];
+    if (options.debug) {
+      this.debug = (...args) => console.error(...args);
+    }
+    this.debug(this.pattern, this.globSet);
+    const rawGlobParts = this.globSet.map((s) => this.slashSplit(s));
+    this.globParts = this.preprocess(rawGlobParts);
+    this.debug(this.pattern, this.globParts);
+    let set2 = this.globParts.map((s, _, __) => {
+      if (this.isWindows && this.windowsNoMagicRoot) {
+        const isUNC = s[0] === "" && s[1] === "" && (s[2] === "?" || !globMagic.test(s[2])) && !globMagic.test(s[3]);
+        const isDrive = /^[a-z]:/i.test(s[0]);
+        if (isUNC) {
+          return [
+            ...s.slice(0, 4),
+            ...s.slice(4).map((ss) => this.parse(ss))
+          ];
+        } else if (isDrive) {
+          return [s[0], ...s.slice(1).map((ss) => this.parse(ss))];
+        }
+      }
+      return s.map((ss) => this.parse(ss));
+    });
+    this.debug(this.pattern, set2);
+    this.set = set2.filter((s) => s.indexOf(false) === -1);
+    if (this.isWindows) {
+      for (let i = 0; i < this.set.length; i++) {
+        const p = this.set[i];
+        if (p[0] === "" && p[1] === "" && this.globParts[i][2] === "?" && typeof p[3] === "string" && /^[a-z]:$/i.test(p[3])) {
+          p[2] = "?";
+        }
+      }
+    }
+    this.debug(this.pattern, this.set);
+  }
+  // various transforms to equivalent pattern sets that are
+  // faster to process in a filesystem walk.  The goal is to
+  // eliminate what we can, and push all ** patterns as far
+  // to the right as possible, even if it increases the number
+  // of patterns that we have to process.
+  preprocess(globParts) {
+    if (this.options.noglobstar) {
+      for (const partset of globParts) {
+        for (let j = 0; j < partset.length; j++) {
+          if (partset[j] === "**") {
+            partset[j] = "*";
+          }
+        }
+      }
+    }
+    const { optimizationLevel = 1 } = this.options;
+    if (optimizationLevel >= 2) {
+      globParts = this.firstPhasePreProcess(globParts);
+      globParts = this.secondPhasePreProcess(globParts);
+    } else if (optimizationLevel >= 1) {
+      globParts = this.levelOneOptimize(globParts);
+    } else {
+      globParts = this.adjascentGlobstarOptimize(globParts);
+    }
+    return globParts;
+  }
+  // just get rid of adjascent ** portions
+  adjascentGlobstarOptimize(globParts) {
+    return globParts.map((parts) => {
+      let gs = -1;
+      while (-1 !== (gs = parts.indexOf("**", gs + 1))) {
+        let i = gs;
+        while (parts[i + 1] === "**") {
+          i++;
+        }
+        if (i !== gs) {
+          parts.splice(gs, i - gs);
+        }
+      }
+      return parts;
+    });
+  }
+  // get rid of adjascent ** and resolve .. portions
+  levelOneOptimize(globParts) {
+    return globParts.map((parts) => {
+      parts = parts.reduce((set2, part) => {
+        const prev = set2[set2.length - 1];
+        if (part === "**" && prev === "**") {
+          return set2;
+        }
+        if (part === "..") {
+          if (prev && prev !== ".." && prev !== "." && prev !== "**") {
+            set2.pop();
+            return set2;
+          }
+        }
+        set2.push(part);
+        return set2;
+      }, []);
+      return parts.length === 0 ? [""] : parts;
+    });
+  }
+  levelTwoFileOptimize(parts) {
+    if (!Array.isArray(parts)) {
+      parts = this.slashSplit(parts);
+    }
+    let didSomething = false;
+    do {
+      didSomething = false;
+      if (!this.preserveMultipleSlashes) {
+        for (let i = 1; i < parts.length - 1; i++) {
+          const p = parts[i];
+          if (i === 1 && p === "" && parts[0] === "")
+            continue;
+          if (p === "." || p === "") {
+            didSomething = true;
+            parts.splice(i, 1);
+            i--;
+          }
+        }
+        if (parts[0] === "." && parts.length === 2 && (parts[1] === "." || parts[1] === "")) {
+          didSomething = true;
+          parts.pop();
+        }
+      }
+      let dd = 0;
+      while (-1 !== (dd = parts.indexOf("..", dd + 1))) {
+        const p = parts[dd - 1];
+        if (p && p !== "." && p !== ".." && p !== "**" && !(this.isWindows && /^[a-z]:$/i.test(p))) {
+          didSomething = true;
+          parts.splice(dd - 1, 2);
+          dd -= 2;
+        }
+      }
+    } while (didSomething);
+    return parts.length === 0 ? [""] : parts;
+  }
+  // First phase: single-pattern processing
+  // <pre> is 1 or more portions
+  // <rest> is 1 or more portions
+  // <p> is any portion other than ., .., '', or **
+  // <e> is . or ''
+  //
+  // **/.. is *brutal* for filesystem walking performance, because
+  // it effectively resets the recursive walk each time it occurs,
+  // and ** cannot be reduced out by a .. pattern part like a regexp
+  // or most strings (other than .., ., and '') can be.
+  //
+  // <pre>/**/../<p>/<p>/<rest> -> {<pre>/../<p>/<p>/<rest>,<pre>/**/<p>/<p>/<rest>}
+  // <pre>/<e>/<rest> -> <pre>/<rest>
+  // <pre>/<p>/../<rest> -> <pre>/<rest>
+  // **/**/<rest> -> **/<rest>
+  //
+  // **/*/<rest> -> */**/<rest> <== not valid because ** doesn't follow
+  // this WOULD be allowed if ** did follow symlinks, or * didn't
+  firstPhasePreProcess(globParts) {
+    let didSomething = false;
+    do {
+      didSomething = false;
+      for (let parts of globParts) {
+        let gs = -1;
+        while (-1 !== (gs = parts.indexOf("**", gs + 1))) {
+          let gss = gs;
+          while (parts[gss + 1] === "**") {
+            gss++;
+          }
+          if (gss > gs) {
+            parts.splice(gs + 1, gss - gs);
+          }
+          let next = parts[gs + 1];
+          const p = parts[gs + 2];
+          const p2 = parts[gs + 3];
+          if (next !== "..")
+            continue;
+          if (!p || p === "." || p === ".." || !p2 || p2 === "." || p2 === "..") {
+            continue;
+          }
+          didSomething = true;
+          parts.splice(gs, 1);
+          const other = parts.slice(0);
+          other[gs] = "**";
+          globParts.push(other);
+          gs--;
+        }
+        if (!this.preserveMultipleSlashes) {
+          for (let i = 1; i < parts.length - 1; i++) {
+            const p = parts[i];
+            if (i === 1 && p === "" && parts[0] === "")
+              continue;
+            if (p === "." || p === "") {
+              didSomething = true;
+              parts.splice(i, 1);
+              i--;
+            }
+          }
+          if (parts[0] === "." && parts.length === 2 && (parts[1] === "." || parts[1] === "")) {
+            didSomething = true;
+            parts.pop();
+          }
+        }
+        let dd = 0;
+        while (-1 !== (dd = parts.indexOf("..", dd + 1))) {
+          const p = parts[dd - 1];
+          if (p && p !== "." && p !== ".." && p !== "**") {
+            didSomething = true;
+            const needDot = dd === 1 && parts[dd + 1] === "**";
+            const splin = needDot ? ["."] : [];
+            parts.splice(dd - 1, 2, ...splin);
+            if (parts.length === 0)
+              parts.push("");
+            dd -= 2;
+          }
+        }
+      }
+    } while (didSomething);
+    return globParts;
+  }
+  // second phase: multi-pattern dedupes
+  // {<pre>/*/<rest>,<pre>/<p>/<rest>} -> <pre>/*/<rest>
+  // {<pre>/<rest>,<pre>/<rest>} -> <pre>/<rest>
+  // {<pre>/**/<rest>,<pre>/<rest>} -> <pre>/**/<rest>
+  //
+  // {<pre>/**/<rest>,<pre>/**/<p>/<rest>} -> <pre>/**/<rest>
+  // ^-- not valid because ** doens't follow symlinks
+  secondPhasePreProcess(globParts) {
+    for (let i = 0; i < globParts.length - 1; i++) {
+      for (let j = i + 1; j < globParts.length; j++) {
+        const matched = this.partsMatch(globParts[i], globParts[j], !this.preserveMultipleSlashes);
+        if (matched) {
+          globParts[i] = [];
+          globParts[j] = matched;
+          break;
+        }
+      }
+    }
+    return globParts.filter((gs) => gs.length);
+  }
+  partsMatch(a, b, emptyGSMatch = false) {
+    let ai = 0;
+    let bi = 0;
+    let result = [];
+    let which = "";
+    while (ai < a.length && bi < b.length) {
+      if (a[ai] === b[bi]) {
+        result.push(which === "b" ? b[bi] : a[ai]);
+        ai++;
+        bi++;
+      } else if (emptyGSMatch && a[ai] === "**" && b[bi] === a[ai + 1]) {
+        result.push(a[ai]);
+        ai++;
+      } else if (emptyGSMatch && b[bi] === "**" && a[ai] === b[bi + 1]) {
+        result.push(b[bi]);
+        bi++;
+      } else if (a[ai] === "*" && b[bi] && (this.options.dot || !b[bi].startsWith(".")) && b[bi] !== "**") {
+        if (which === "b")
+          return false;
+        which = "a";
+        result.push(a[ai]);
+        ai++;
+        bi++;
+      } else if (b[bi] === "*" && a[ai] && (this.options.dot || !a[ai].startsWith(".")) && a[ai] !== "**") {
+        if (which === "a")
+          return false;
+        which = "b";
+        result.push(b[bi]);
+        ai++;
+        bi++;
+      } else {
+        return false;
+      }
+    }
+    return a.length === b.length && result;
+  }
+  parseNegate() {
+    if (this.nonegate)
+      return;
+    const pattern = this.pattern;
+    let negate = false;
+    let negateOffset = 0;
+    for (let i = 0; i < pattern.length && pattern.charAt(i) === "!"; i++) {
+      negate = !negate;
+      negateOffset++;
+    }
+    if (negateOffset)
+      this.pattern = pattern.slice(negateOffset);
+    this.negate = negate;
+  }
+  // set partial to true to test if, for example,
+  // "/a/b" matches the start of "/*/b/*/d"
+  // Partial means, if you run out of file before you run
+  // out of pattern, then that's fine, as long as all
+  // the parts match.
+  matchOne(file, pattern, partial = false) {
+    let fileStartIndex = 0;
+    let patternStartIndex = 0;
+    if (this.isWindows) {
+      const fileDrive = typeof file[0] === "string" && /^[a-z]:$/i.test(file[0]);
+      const fileUNC = !fileDrive && file[0] === "" && file[1] === "" && file[2] === "?" && /^[a-z]:$/i.test(file[3]);
+      const patternDrive = typeof pattern[0] === "string" && /^[a-z]:$/i.test(pattern[0]);
+      const patternUNC = !patternDrive && pattern[0] === "" && pattern[1] === "" && pattern[2] === "?" && typeof pattern[3] === "string" && /^[a-z]:$/i.test(pattern[3]);
+      const fdi = fileUNC ? 3 : fileDrive ? 0 : void 0;
+      const pdi = patternUNC ? 3 : patternDrive ? 0 : void 0;
+      if (typeof fdi === "number" && typeof pdi === "number") {
+        const [fd, pd] = [
+          file[fdi],
+          pattern[pdi]
+        ];
+        if (fd.toLowerCase() === pd.toLowerCase()) {
+          pattern[pdi] = fd;
+          patternStartIndex = pdi;
+          fileStartIndex = fdi;
+        }
+      }
+    }
+    const { optimizationLevel = 1 } = this.options;
+    if (optimizationLevel >= 2) {
+      file = this.levelTwoFileOptimize(file);
+    }
+    if (pattern.includes(GLOBSTAR)) {
+      return this.#matchGlobstar(file, pattern, partial, fileStartIndex, patternStartIndex);
+    }
+    return this.#matchOne(file, pattern, partial, fileStartIndex, patternStartIndex);
+  }
+  #matchGlobstar(file, pattern, partial, fileIndex, patternIndex) {
+    const firstgs = pattern.indexOf(GLOBSTAR, patternIndex);
+    const lastgs = pattern.lastIndexOf(GLOBSTAR);
+    const [head, body, tail] = partial ? [
+      pattern.slice(patternIndex, firstgs),
+      pattern.slice(firstgs + 1),
+      []
+    ] : [
+      pattern.slice(patternIndex, firstgs),
+      pattern.slice(firstgs + 1, lastgs),
+      pattern.slice(lastgs + 1)
+    ];
+    if (head.length) {
+      const fileHead = file.slice(fileIndex, fileIndex + head.length);
+      if (!this.#matchOne(fileHead, head, partial, 0, 0)) {
+        return false;
+      }
+      fileIndex += head.length;
+      patternIndex += head.length;
+    }
+    let fileTailMatch = 0;
+    if (tail.length) {
+      if (tail.length + fileIndex > file.length)
+        return false;
+      let tailStart = file.length - tail.length;
+      if (this.#matchOne(file, tail, partial, tailStart, 0)) {
+        fileTailMatch = tail.length;
+      } else {
+        if (file[file.length - 1] !== "" || fileIndex + tail.length === file.length) {
+          return false;
+        }
+        tailStart--;
+        if (!this.#matchOne(file, tail, partial, tailStart, 0)) {
+          return false;
+        }
+        fileTailMatch = tail.length + 1;
+      }
+    }
+    if (!body.length) {
+      let sawSome = !!fileTailMatch;
+      for (let i2 = fileIndex; i2 < file.length - fileTailMatch; i2++) {
+        const f = String(file[i2]);
+        sawSome = true;
+        if (f === "." || f === ".." || !this.options.dot && f.startsWith(".")) {
+          return false;
+        }
+      }
+      return partial || sawSome;
+    }
+    const bodySegments = [[[], 0]];
+    let currentBody = bodySegments[0];
+    let nonGsParts = 0;
+    const nonGsPartsSums = [0];
+    for (const b of body) {
+      if (b === GLOBSTAR) {
+        nonGsPartsSums.push(nonGsParts);
+        currentBody = [[], 0];
+        bodySegments.push(currentBody);
+      } else {
+        currentBody[0].push(b);
+        nonGsParts++;
+      }
+    }
+    let i = bodySegments.length - 1;
+    const fileLength = file.length - fileTailMatch;
+    for (const b of bodySegments) {
+      b[1] = fileLength - (nonGsPartsSums[i--] + b[0].length);
+    }
+    return !!this.#matchGlobStarBodySections(file, bodySegments, fileIndex, 0, partial, 0, !!fileTailMatch);
+  }
+  // return false for "nope, not matching"
+  // return null for "not matching, cannot keep trying"
+  #matchGlobStarBodySections(file, bodySegments, fileIndex, bodyIndex, partial, globStarDepth, sawTail) {
+    const bs = bodySegments[bodyIndex];
+    if (!bs) {
+      for (let i = fileIndex; i < file.length; i++) {
+        sawTail = true;
+        const f = file[i];
+        if (f === "." || f === ".." || !this.options.dot && f.startsWith(".")) {
+          return false;
+        }
+      }
+      return sawTail;
+    }
+    const [body, after] = bs;
+    while (fileIndex <= after) {
+      const m = this.#matchOne(file.slice(0, fileIndex + body.length), body, partial, fileIndex, 0);
+      if (m && globStarDepth < this.maxGlobstarRecursion) {
+        const sub = this.#matchGlobStarBodySections(file, bodySegments, fileIndex + body.length, bodyIndex + 1, partial, globStarDepth + 1, sawTail);
+        if (sub !== false) {
+          return sub;
+        }
+      }
+      const f = file[fileIndex];
+      if (f === "." || f === ".." || !this.options.dot && f.startsWith(".")) {
+        return false;
+      }
+      fileIndex++;
+    }
+    return partial || null;
+  }
+  #matchOne(file, pattern, partial, fileIndex, patternIndex) {
+    let fi;
+    let pi;
+    let pl;
+    let fl;
+    for (fi = fileIndex, pi = patternIndex, fl = file.length, pl = pattern.length; fi < fl && pi < pl; fi++, pi++) {
+      this.debug("matchOne loop");
+      let p = pattern[pi];
+      let f = file[fi];
+      this.debug(pattern, p, f);
+      if (p === false || p === GLOBSTAR) {
+        return false;
+      }
+      let hit;
+      if (typeof p === "string") {
+        hit = f === p;
+        this.debug("string match", p, f, hit);
+      } else {
+        hit = p.test(f);
+        this.debug("pattern match", p, f, hit);
+      }
+      if (!hit)
+        return false;
+    }
+    if (fi === fl && pi === pl) {
+      return true;
+    } else if (fi === fl) {
+      return partial;
+    } else if (pi === pl) {
+      return fi === fl - 1 && file[fi] === "";
+    } else {
+      throw new Error("wtf?");
+    }
+  }
+  braceExpand() {
+    return braceExpand(this.pattern, this.options);
+  }
+  parse(pattern) {
+    assertValidPattern(pattern);
+    const options = this.options;
+    if (pattern === "**")
+      return GLOBSTAR;
+    if (pattern === "")
+      return "";
+    let m;
+    let fastTest = null;
+    if (m = pattern.match(starRE)) {
+      fastTest = options.dot ? starTestDot : starTest;
+    } else if (m = pattern.match(starDotExtRE)) {
+      fastTest = (options.nocase ? options.dot ? starDotExtTestNocaseDot : starDotExtTestNocase : options.dot ? starDotExtTestDot : starDotExtTest)(m[1]);
+    } else if (m = pattern.match(qmarksRE)) {
+      fastTest = (options.nocase ? options.dot ? qmarksTestNocaseDot : qmarksTestNocase : options.dot ? qmarksTestDot : qmarksTest)(m);
+    } else if (m = pattern.match(starDotStarRE)) {
+      fastTest = options.dot ? starDotStarTestDot : starDotStarTest;
+    } else if (m = pattern.match(dotStarRE)) {
+      fastTest = dotStarTest;
+    }
+    const re = AST.fromGlob(pattern, this.options).toMMPattern();
+    if (fastTest && typeof re === "object") {
+      Reflect.defineProperty(re, "test", { value: fastTest });
+    }
+    return re;
+  }
+  makeRe() {
+    if (this.regexp || this.regexp === false)
+      return this.regexp;
+    const set2 = this.set;
+    if (!set2.length) {
+      this.regexp = false;
+      return this.regexp;
+    }
+    const options = this.options;
+    const twoStar = options.noglobstar ? star2 : options.dot ? twoStarDot : twoStarNoDot;
+    const flags = new Set(options.nocase ? ["i"] : []);
+    let re = set2.map((pattern) => {
+      const pp = pattern.map((p) => {
+        if (p instanceof RegExp) {
+          for (const f of p.flags.split(""))
+            flags.add(f);
+        }
+        return typeof p === "string" ? regExpEscape2(p) : p === GLOBSTAR ? GLOBSTAR : p._src;
+      });
+      pp.forEach((p, i) => {
+        const next = pp[i + 1];
+        const prev = pp[i - 1];
+        if (p !== GLOBSTAR || prev === GLOBSTAR) {
+          return;
+        }
+        if (prev === void 0) {
+          if (next !== void 0 && next !== GLOBSTAR) {
+            pp[i + 1] = "(?:\\/|" + twoStar + "\\/)?" + next;
+          } else {
+            pp[i] = twoStar;
+          }
+        } else if (next === void 0) {
+          pp[i - 1] = prev + "(?:\\/|\\/" + twoStar + ")?";
+        } else if (next !== GLOBSTAR) {
+          pp[i - 1] = prev + "(?:\\/|\\/" + twoStar + "\\/)" + next;
+          pp[i + 1] = GLOBSTAR;
+        }
+      });
+      const filtered = pp.filter((p) => p !== GLOBSTAR);
+      if (this.partial && filtered.length >= 1) {
+        const prefixes = [];
+        for (let i = 1; i <= filtered.length; i++) {
+          prefixes.push(filtered.slice(0, i).join("/"));
+        }
+        return "(?:" + prefixes.join("|") + ")";
+      }
+      return filtered.join("/");
+    }).join("|");
+    const [open, close] = set2.length > 1 ? ["(?:", ")"] : ["", ""];
+    re = "^" + open + re + close + "$";
+    if (this.partial) {
+      re = "^(?:\\/|" + open + re.slice(1, -1) + close + ")$";
+    }
+    if (this.negate)
+      re = "^(?!" + re + ").+$";
+    try {
+      this.regexp = new RegExp(re, [...flags].join(""));
+    } catch {
+      this.regexp = false;
+    }
+    return this.regexp;
+  }
+  slashSplit(p) {
+    if (this.preserveMultipleSlashes) {
+      return p.split("/");
+    } else if (this.isWindows && /^\/\/[^/]+/.test(p)) {
+      return ["", ...p.split(/\/+/)];
+    } else {
+      return p.split(/\/+/);
+    }
+  }
+  match(f, partial = this.partial) {
+    this.debug("match", f, this.pattern);
+    if (this.comment) {
+      return false;
+    }
+    if (this.empty) {
+      return f === "";
+    }
+    if (f === "/" && partial) {
+      return true;
+    }
+    const options = this.options;
+    if (this.isWindows) {
+      f = f.split("\\").join("/");
+    }
+    const ff = this.slashSplit(f);
+    this.debug(this.pattern, "split", ff);
+    const set2 = this.set;
+    this.debug(this.pattern, "set", set2);
+    let filename = ff[ff.length - 1];
+    if (!filename) {
+      for (let i = ff.length - 2; !filename && i >= 0; i--) {
+        filename = ff[i];
+      }
+    }
+    for (const pattern of set2) {
+      let file = ff;
+      if (options.matchBase && pattern.length === 1) {
+        file = [filename];
+      }
+      const hit = this.matchOne(file, pattern, partial);
+      if (hit) {
+        if (options.flipNegate) {
+          return true;
+        }
+        return !this.negate;
+      }
+    }
+    if (options.flipNegate) {
+      return false;
+    }
+    return this.negate;
+  }
+  static defaults(def) {
+    return minimatch.defaults(def).Minimatch;
+  }
+};
+minimatch.AST = AST;
+minimatch.Minimatch = Minimatch;
+minimatch.escape = escape;
+minimatch.unescape = unescape;
 
 // src/abstractions/summary.ts
 var Summary = class {
@@ -38306,7 +40140,7 @@ var Summary = class {
 };
 
 // src/api/translation-api.ts
-var import_core3 = __toESM(require_core());
+var import_core4 = __toESM(require_core());
 var import_node_crypto = require("node:crypto");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -40262,11 +42096,11 @@ function allowInsecureConnection(request2, options) {
   return false;
 }
 function emitInsecureConnectionWarning() {
-  const warning5 = "Sending token over insecure transport. Assume any token issued is compromised.";
-  logger.warning(warning5);
+  const warning6 = "Sending token over insecure transport. Assume any token issued is compromised.";
+  logger.warning(warning6);
   if (typeof process?.emitWarning === "function" && !insecureConnectionWarningEmmitted) {
     insecureConnectionWarningEmmitted = true;
-    process.emitWarning(warning5);
+    process.emitWarning(warning6);
   }
 }
 function ensureSecureConnection(request2, options) {
@@ -42190,6 +44024,120 @@ var toRawTextArray = (translationResults, locale) => {
   return rawTextArray;
 };
 
+// src/helpers/placeholders.ts
+var DEFAULT_PLACEHOLDER_PATTERNS = [
+  // i18next / Mustache / Handlebars: {{name}} or {{ name }}
+  /\{\{\s*[\w.\-:|]+\s*\}\}/g,
+  // ES template literals / shell-ish: ${name}
+  /\$\{[\w.-]+\}/g,
+  // .NET / C# / Java composite formatting: {0}, {0:format}, {name}, {name,10:N2}
+  /\{\d+(?:[,:][^{}]*)?\}/g,
+  /\{[A-Za-z_][\w.-]*(?:[,:][^{}]*)?\}/g,
+  // printf positional & flagged: %1$s, %2$d, %.2f, %-10s
+  /%\d+\$[#\-+ 0,]*\d*(?:\.\d+)?[diouxXeEfgGsScCpn%]/g,
+  /%[#\-+ 0,]*\d*(?:\.\d+)?[diouxXeEfgGsScCpn%]/g,
+  // XML/HTML-ish entities the user pasted as literal source text (e.g. &nbsp;)
+  /&[a-zA-Z]+;/g
+];
+var TOKEN_PREFIX = "RTKEEP";
+var TOKEN_RE = /RTKEEP(\d{6})/g;
+var compileExtraPatterns = (customPatterns) => {
+  if (!customPatterns?.length) return [];
+  const compiled = [];
+  for (const raw of customPatterns) {
+    const trimmed = raw?.trim();
+    if (!trimmed) continue;
+    try {
+      compiled.push(
+        new RegExp(trimmed, trimmed.startsWith("/") ? void 0 : "g")
+      );
+    } catch {
+    }
+  }
+  return compiled;
+};
+var protect = (text, customPatterns) => {
+  const tokens = /* @__PURE__ */ new Map();
+  if (!text) return { protected: text, tokens };
+  const patterns = [
+    ...DEFAULT_PLACEHOLDER_PATTERNS,
+    ...compileExtraPatterns(customPatterns)
+  ];
+  let next = text;
+  let counter = 0;
+  for (const re of patterns) {
+    next = next.replace(re, (match2) => {
+      const token = `${TOKEN_PREFIX}${String(counter++).padStart(6, "0")}`;
+      tokens.set(token, match2);
+      return token;
+    });
+  }
+  return { protected: next, tokens };
+};
+var restore = (text, tokens) => {
+  if (!text || tokens.size === 0) return text;
+  return text.replace(TOKEN_RE, (match2) => tokens.get(match2) ?? match2);
+};
+
+// src/helpers/retry.ts
+var import_core3 = __toESM(require_core());
+var TRANSIENT_STATUSES = /* @__PURE__ */ new Set([408, 425, 429, 500, 502, 503, 504]);
+var parseRetryAfter = (headers, now = Date.now()) => {
+  if (!headers) return void 0;
+  const raw = pickHeader(headers, "retry-after");
+  if (!raw) return void 0;
+  const trimmed = raw.trim();
+  if (!trimmed) return void 0;
+  if (/^\d+(\.\d+)?$/.test(trimmed)) {
+    const seconds = Number.parseFloat(trimmed);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return Math.round(seconds * 1e3);
+    }
+  }
+  const ts = Date.parse(trimmed);
+  if (Number.isFinite(ts)) {
+    const delta = ts - now;
+    return delta > 0 ? delta : 0;
+  }
+  return void 0;
+};
+var pickHeader = (headers, name) => {
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== lower) continue;
+    if (Array.isArray(value)) return value[0];
+    return value;
+  }
+  return void 0;
+};
+var sleep = (ms) => new Promise((resolve4) => setTimeout(resolve4, ms));
+var retryablePost = async (fn, isTransient, options, sleepFn = sleep) => {
+  const maxRetries = Math.max(0, options?.maxRetries ?? 5);
+  const cap = Math.max(0, options?.retryBackoffMs ?? 3e4);
+  let attempt = 0;
+  let response = await fn();
+  while (isTransient(response) && attempt < maxRetries) {
+    const status = Number(response.status);
+    const retryAfterMs = parseRetryAfter(response.headers);
+    const expBackoff = Math.min(
+      cap,
+      Math.round(2 ** attempt * 500 + (Math.random() - 0.5) * 500)
+    );
+    const sleepMs = Math.min(cap, retryAfterMs ?? expBackoff);
+    (0, import_core3.warning)(
+      `Translator returned HTTP ${status} (attempt ${attempt + 1} of ${maxRetries}). Sleeping ${sleepMs}ms before retrying${retryAfterMs !== void 0 ? " (Retry-After honored)" : ""}.`
+    );
+    await sleepFn(Math.max(0, sleepMs));
+    attempt++;
+    response = await fn();
+  }
+  return response;
+};
+var isTransientStatus = (status) => {
+  const n = typeof status === "number" ? status : Number.parseInt(status, 10);
+  return Number.isFinite(n) && TRANSIENT_STATUSES.has(n);
+};
+
 // src/api/translation-api.ts
 var PUBLIC_ENDPOINT = "https://api.cognitive.microsofttranslator.com";
 var buildClient = (endpoint2, apiVersion) => esm_default(endpoint2, { baseUrl: endpoint2, apiVersion });
@@ -42214,7 +44162,7 @@ var getAvailableTranslations = async (apiVersion = "3.0") => {
   }
   return response.body;
 };
-var translate = async (translatorResource, toLocales, translatableText, filePath) => {
+var translate = async (translatorResource, toLocales, translatableText, filePath, options) => {
   try {
     const apiRateLimit = 1e4;
     const numberOfElementsLimit = 100;
@@ -42228,27 +44176,44 @@ var translate = async (translatorResource, toLocales, translatableText, filePath
       }
     });
     if (validationErrors.length) {
-      (0, import_core3.setFailed)(validationErrors.join("\r\n"));
+      (0, import_core4.setFailed)(validationErrors.join("\r\n"));
       return void 0;
     }
-    const data = [...translatableText.values()].map((value) => ({
-      text: value
-    }));
+    const protectEnabled = options?.protectPlaceholders !== false;
+    const sentinelMaps = [];
+    const data = [...translatableText.values()].map((value) => {
+      if (!protectEnabled) {
+        sentinelMaps.push(/* @__PURE__ */ new Map());
+        return { text: value };
+      }
+      const { protected: p, tokens } = protect(
+        value,
+        options?.customPlaceholderPatterns
+      );
+      sentinelMaps.push(tokens);
+      return { text: p };
+    });
     const apiVersion = translatorResource.apiVersion ?? "3.0";
     const client = buildClient(translatorResource.endpoint, apiVersion);
     const headers = buildAuthHeaders(translatorResource);
     const characters = JSON.stringify(data).length;
     const batchedData = characters > apiRateLimit || data.length > numberOfElementsLimit ? batch(data, numberOfElementsLimit, apiRateLimit) : [data];
     let results = [];
+    let nextSentinelOffset = 0;
     for (let i = 0; i < batchedData.length; i++) {
       const dataBatch = batchedData[i];
       const batchCharacters = JSON.stringify(dataBatch).length;
       const localeCount = toLocales.length;
       const localesBatchSize = Math.floor(apiRateLimit / batchCharacters);
       const batchedLocales = localesBatchSize < localeCount ? chunk(toLocales, localesBatchSize) : [toLocales];
+      const sentinelsForBatch = sentinelMaps.slice(
+        nextSentinelOffset,
+        nextSentinelOffset + dataBatch.length
+      );
+      nextSentinelOffset += dataBatch.length;
       for (let j = 0; j < batchedLocales.length; j++) {
         const locales = batchedLocales[j];
-        (0, import_core3.debug)(
+        (0, import_core4.debug)(
           `Data batch ${i + 1}, Locales batch ${j + 1}, locales: ${locales.join(
             ", "
           )}`
@@ -42272,26 +44237,43 @@ var translate = async (translatorResource, toLocales, translatableText, filePath
             allowFallback: translatorResource.allowFallback
           }
         };
-        const response = await client.path("/translate").post({
-          body: dataBatch,
-          headers,
-          queryParameters
-        });
+        const response = await retryablePost(
+          () => client.path("/translate").post({
+            body: dataBatch,
+            headers,
+            queryParameters
+          }),
+          (resp) => isUnexpected(resp) && isTransientStatus(resp.status),
+          {
+            maxRetries: options?.maxRetries,
+            retryBackoffMs: options?.retryBackoffMs
+          }
+        );
         if (isUnexpected(response)) {
           const azureError = response.body?.error;
           if (azureError && (azureError.code || azureError.message)) {
-            (0, import_core3.setFailed)(
+            (0, import_core4.setFailed)(
               `file: ${filePath}, error: { code: ${azureError.code}, message: '${azureError.message}' }`
             );
           } else {
-            (0, import_core3.setFailed)(
+            (0, import_core4.setFailed)(
               `Failed to translate input: file '${filePath}', HTTP ${response.status}`
             );
           }
           return void 0;
         }
         const responseData = response.body;
-        (0, import_core3.debug)(
+        if (protectEnabled) {
+          responseData.forEach((row, k) => {
+            const tokens = sentinelsForBatch[k];
+            if (!tokens || tokens.size === 0) return;
+            row.translations = row.translations.map((t) => ({
+              ...t,
+              text: restore(t.text, tokens)
+            }));
+          });
+        }
+        (0, import_core4.debug)(
           `Data batch ${i + 1}, Locales batch ${j + 1}, response: ${JSON.stringify(responseData)}`
         );
         results = [...results, ...responseData];
@@ -42301,19 +44283,19 @@ var translate = async (translatorResource, toLocales, translatableText, filePath
   } catch (ex) {
     const legacyAzureError = ex?.response?.data?.error;
     if (legacyAzureError && (legacyAzureError.code || legacyAzureError.message)) {
-      (0, import_core3.setFailed)(
+      (0, import_core4.setFailed)(
         `file: ${filePath}, error: { code: ${legacyAzureError.code}, message: '${legacyAzureError.message}' }`
       );
     } else {
       const message = ex instanceof Error ? ex.message : String(ex);
-      (0, import_core3.setFailed)(`Failed to translate input: file '${filePath}', ${message}`);
+      (0, import_core4.setFailed)(`Failed to translate input: file '${filePath}', ${message}`);
     }
     return void 0;
   }
 };
 
 // src/parsers/json-parser.ts
-var import_core4 = __toESM(require_core());
+var import_core5 = __toESM(require_core());
 var JsonParser = class _JsonParser {
   static DELIMITER = "[--]";
   parseFrom(fileContent) {
@@ -42360,7 +44342,7 @@ var JsonParser = class _JsonParser {
       );
     }
     if (containsTranslatableArray) {
-      (0, import_core4.warning)(
+      (0, import_core5.warning)(
         "JsonParser: encountered an array containing strings \u2014 array values are preserved verbatim and NOT translated. Restructure into nested objects to translate them."
       );
     }
@@ -42466,7 +44448,7 @@ var PortableObjectToken = class {
 };
 
 // src/parsers/po-parser.ts
-var import_core5 = __toESM(require_core());
+var import_core6 = __toESM(require_core());
 var PortableObjectParser = class {
   async parseFrom(fileContent) {
     await delay3(0, null);
@@ -42531,7 +44513,7 @@ var PortableObjectParser = class {
         if (token.id === "msgid" || token.id === "msgid_plural") {
           if (token.value && skipMsgids.has(token.value)) {
             if (!warnedMultiline) {
-              (0, import_core5.warning)(
+              (0, import_core6.warning)(
                 "PortableObjectParser: multi-line PO continuations (in msgid or msgstr) are not yet supported and will be left unchanged. See https://github.com/IEvangelist/resource-translator/issues for status."
               );
               warnedMultiline = true;
@@ -42882,7 +44864,7 @@ var buildTermRegex = (term) => {
 };
 
 // src/helpers/summarizer.ts
-var import_core6 = __toESM(require_core());
+var import_core7 = __toESM(require_core());
 var summarize = (summary) => {
   const fileCount = summary.totalFileCount.toLocaleString("en");
   const translations = summary.totalTranslations.toLocaleString("en");
@@ -42915,7 +44897,7 @@ var summarize = (summary) => {
     "",
     "> These machine translations are a result of Azure Cognitive Services Translator, and the [Machine Translator](https://github.com/marketplace/actions/resource-translator) GitHub action. For more information, see [Translator v3.0](https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-reference?WT.mc_id=dapine). To post an issue, or feature request please do so [here](https://github.com/IEvangelist/resource-translator/issues)."
   ];
-  (0, import_core6.debug)(
+  (0, import_core7.debug)(
     JSON.stringify({
       title,
       details
@@ -42925,1831 +44907,27 @@ var summarize = (summary) => {
 };
 
 // src/io/reader-writer.ts
-var import_core7 = __toESM(require_core());
+var import_core8 = __toESM(require_core());
 var import_fs = require("fs");
 var import_path2 = require("path");
 function readFile(path2) {
   const resolved = (0, import_path2.resolve)(path2);
   const file = (0, import_fs.readFileSync)(resolved, "utf-8");
-  (0, import_core7.debug)(`Read file: ${file}`);
+  (0, import_core8.debug)(`Read file: ${file}`);
   return file;
 }
 function writeFile(path2, content) {
-  (0, import_core7.debug)(`Write file, path: ${path2}
+  (0, import_core8.debug)(`Write file, path: ${path2}
 Content: ${content}`);
   (0, import_fs.writeFileSync)(path2, content);
 }
 
 // src/io/translation-file-finder.ts
-var import_core8 = __toESM(require_core());
+var import_core9 = __toESM(require_core());
 var import_github = __toESM(require_github());
 var import_glob = __toESM(require_glob());
 var import_node_fs2 = require("node:fs");
 var import_path3 = require("path");
-
-// node_modules/brace-expansion/node_modules/balanced-match/dist/esm/index.js
-var balanced = (a, b, str2) => {
-  const ma = a instanceof RegExp ? maybeMatch(a, str2) : a;
-  const mb = b instanceof RegExp ? maybeMatch(b, str2) : b;
-  const r = ma !== null && mb != null && range(ma, mb, str2);
-  return r && {
-    start: r[0],
-    end: r[1],
-    pre: str2.slice(0, r[0]),
-    body: str2.slice(r[0] + ma.length, r[1]),
-    post: str2.slice(r[1] + mb.length)
-  };
-};
-var maybeMatch = (reg, str2) => {
-  const m = str2.match(reg);
-  return m ? m[0] : null;
-};
-var range = (a, b, str2) => {
-  let begs, beg, left, right = void 0, result;
-  let ai = str2.indexOf(a);
-  let bi = str2.indexOf(b, ai + 1);
-  let i = ai;
-  if (ai >= 0 && bi > 0) {
-    if (a === b) {
-      return [ai, bi];
-    }
-    begs = [];
-    left = str2.length;
-    while (i >= 0 && !result) {
-      if (i === ai) {
-        begs.push(i);
-        ai = str2.indexOf(a, i + 1);
-      } else if (begs.length === 1) {
-        const r = begs.pop();
-        if (r !== void 0)
-          result = [r, bi];
-      } else {
-        beg = begs.pop();
-        if (beg !== void 0 && beg < left) {
-          left = beg;
-          right = bi;
-        }
-        bi = str2.indexOf(b, i + 1);
-      }
-      i = ai < bi && ai >= 0 ? ai : bi;
-    }
-    if (begs.length && right !== void 0) {
-      result = [left, right];
-    }
-  }
-  return result;
-};
-
-// node_modules/brace-expansion/dist/esm/index.js
-var escSlash = "\0SLASH" + Math.random() + "\0";
-var escOpen = "\0OPEN" + Math.random() + "\0";
-var escClose = "\0CLOSE" + Math.random() + "\0";
-var escComma = "\0COMMA" + Math.random() + "\0";
-var escPeriod = "\0PERIOD" + Math.random() + "\0";
-var escSlashPattern = new RegExp(escSlash, "g");
-var escOpenPattern = new RegExp(escOpen, "g");
-var escClosePattern = new RegExp(escClose, "g");
-var escCommaPattern = new RegExp(escComma, "g");
-var escPeriodPattern = new RegExp(escPeriod, "g");
-var slashPattern = /\\\\/g;
-var openPattern = /\\{/g;
-var closePattern = /\\}/g;
-var commaPattern = /\\,/g;
-var periodPattern = /\\\./g;
-var EXPANSION_MAX = 1e5;
-function numeric(str2) {
-  return !isNaN(str2) ? parseInt(str2, 10) : str2.charCodeAt(0);
-}
-function escapeBraces(str2) {
-  return str2.replace(slashPattern, escSlash).replace(openPattern, escOpen).replace(closePattern, escClose).replace(commaPattern, escComma).replace(periodPattern, escPeriod);
-}
-function unescapeBraces(str2) {
-  return str2.replace(escSlashPattern, "\\").replace(escOpenPattern, "{").replace(escClosePattern, "}").replace(escCommaPattern, ",").replace(escPeriodPattern, ".");
-}
-function parseCommaParts(str2) {
-  if (!str2) {
-    return [""];
-  }
-  const parts = [];
-  const m = balanced("{", "}", str2);
-  if (!m) {
-    return str2.split(",");
-  }
-  const { pre, body, post } = m;
-  const p = pre.split(",");
-  p[p.length - 1] += "{" + body + "}";
-  const postParts = parseCommaParts(post);
-  if (post.length) {
-    ;
-    p[p.length - 1] += postParts.shift();
-    p.push.apply(p, postParts);
-  }
-  parts.push.apply(parts, p);
-  return parts;
-}
-function expand2(str2, options = {}) {
-  if (!str2) {
-    return [];
-  }
-  const { max = EXPANSION_MAX } = options;
-  if (str2.slice(0, 2) === "{}") {
-    str2 = "\\{\\}" + str2.slice(2);
-  }
-  return expand_(escapeBraces(str2), max, true).map(unescapeBraces);
-}
-function embrace(str2) {
-  return "{" + str2 + "}";
-}
-function isPadded(el) {
-  return /^-?0\d/.test(el);
-}
-function lte(i, y) {
-  return i <= y;
-}
-function gte(i, y) {
-  return i >= y;
-}
-function expand_(str2, max, isTop) {
-  const expansions = [];
-  const m = balanced("{", "}", str2);
-  if (!m)
-    return [str2];
-  const pre = m.pre;
-  const post = m.post.length ? expand_(m.post, max, false) : [""];
-  if (/\$$/.test(m.pre)) {
-    for (let k = 0; k < post.length && k < max; k++) {
-      const expansion = pre + "{" + m.body + "}" + post[k];
-      expansions.push(expansion);
-    }
-  } else {
-    const isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body);
-    const isAlphaSequence = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(m.body);
-    const isSequence = isNumericSequence || isAlphaSequence;
-    const isOptions = m.body.indexOf(",") >= 0;
-    if (!isSequence && !isOptions) {
-      if (m.post.match(/,(?!,).*\}/)) {
-        str2 = m.pre + "{" + m.body + escClose + m.post;
-        return expand_(str2, max, true);
-      }
-      return [str2];
-    }
-    let n;
-    if (isSequence) {
-      n = m.body.split(/\.\./);
-    } else {
-      n = parseCommaParts(m.body);
-      if (n.length === 1 && n[0] !== void 0) {
-        n = expand_(n[0], max, false).map(embrace);
-        if (n.length === 1) {
-          return post.map((p) => m.pre + n[0] + p);
-        }
-      }
-    }
-    let N;
-    if (isSequence && n[0] !== void 0 && n[1] !== void 0) {
-      const x = numeric(n[0]);
-      const y = numeric(n[1]);
-      const width = Math.max(n[0].length, n[1].length);
-      let incr = n.length === 3 && n[2] !== void 0 ? Math.max(Math.abs(numeric(n[2])), 1) : 1;
-      let test = lte;
-      const reverse = y < x;
-      if (reverse) {
-        incr *= -1;
-        test = gte;
-      }
-      const pad = n.some(isPadded);
-      N = [];
-      for (let i = x; test(i, y); i += incr) {
-        let c;
-        if (isAlphaSequence) {
-          c = String.fromCharCode(i);
-          if (c === "\\") {
-            c = "";
-          }
-        } else {
-          c = String(i);
-          if (pad) {
-            const need = width - c.length;
-            if (need > 0) {
-              const z = new Array(need + 1).join("0");
-              if (i < 0) {
-                c = "-" + z + c.slice(1);
-              } else {
-                c = z + c;
-              }
-            }
-          }
-        }
-        N.push(c);
-      }
-    } else {
-      N = [];
-      for (let j = 0; j < n.length; j++) {
-        N.push.apply(N, expand_(n[j], max, false));
-      }
-    }
-    for (let j = 0; j < N.length; j++) {
-      for (let k = 0; k < post.length && expansions.length < max; k++) {
-        const expansion = pre + N[j] + post[k];
-        if (!isTop || isSequence || expansion) {
-          expansions.push(expansion);
-        }
-      }
-    }
-  }
-  return expansions;
-}
-
-// node_modules/minimatch/dist/esm/assert-valid-pattern.js
-var MAX_PATTERN_LENGTH = 1024 * 64;
-var assertValidPattern = (pattern) => {
-  if (typeof pattern !== "string") {
-    throw new TypeError("invalid pattern");
-  }
-  if (pattern.length > MAX_PATTERN_LENGTH) {
-    throw new TypeError("pattern is too long");
-  }
-};
-
-// node_modules/minimatch/dist/esm/brace-expressions.js
-var posixClasses = {
-  "[:alnum:]": ["\\p{L}\\p{Nl}\\p{Nd}", true],
-  "[:alpha:]": ["\\p{L}\\p{Nl}", true],
-  "[:ascii:]": ["\\x00-\\x7f", false],
-  "[:blank:]": ["\\p{Zs}\\t", true],
-  "[:cntrl:]": ["\\p{Cc}", true],
-  "[:digit:]": ["\\p{Nd}", true],
-  "[:graph:]": ["\\p{Z}\\p{C}", true, true],
-  "[:lower:]": ["\\p{Ll}", true],
-  "[:print:]": ["\\p{C}", true],
-  "[:punct:]": ["\\p{P}", true],
-  "[:space:]": ["\\p{Z}\\t\\r\\n\\v\\f", true],
-  "[:upper:]": ["\\p{Lu}", true],
-  "[:word:]": ["\\p{L}\\p{Nl}\\p{Nd}\\p{Pc}", true],
-  "[:xdigit:]": ["A-Fa-f0-9", false]
-};
-var braceEscape = (s) => s.replace(/[[\]\\-]/g, "\\$&");
-var regexpEscape = (s) => s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
-var rangesToString = (ranges) => ranges.join("");
-var parseClass = (glob, position) => {
-  const pos = position;
-  if (glob.charAt(pos) !== "[") {
-    throw new Error("not in a brace expression");
-  }
-  const ranges = [];
-  const negs = [];
-  let i = pos + 1;
-  let sawStart = false;
-  let uflag = false;
-  let escaping = false;
-  let negate = false;
-  let endPos = pos;
-  let rangeStart = "";
-  WHILE: while (i < glob.length) {
-    const c = glob.charAt(i);
-    if ((c === "!" || c === "^") && i === pos + 1) {
-      negate = true;
-      i++;
-      continue;
-    }
-    if (c === "]" && sawStart && !escaping) {
-      endPos = i + 1;
-      break;
-    }
-    sawStart = true;
-    if (c === "\\") {
-      if (!escaping) {
-        escaping = true;
-        i++;
-        continue;
-      }
-    }
-    if (c === "[" && !escaping) {
-      for (const [cls, [unip, u, neg]] of Object.entries(posixClasses)) {
-        if (glob.startsWith(cls, i)) {
-          if (rangeStart) {
-            return ["$.", false, glob.length - pos, true];
-          }
-          i += cls.length;
-          if (neg)
-            negs.push(unip);
-          else
-            ranges.push(unip);
-          uflag = uflag || u;
-          continue WHILE;
-        }
-      }
-    }
-    escaping = false;
-    if (rangeStart) {
-      if (c > rangeStart) {
-        ranges.push(braceEscape(rangeStart) + "-" + braceEscape(c));
-      } else if (c === rangeStart) {
-        ranges.push(braceEscape(c));
-      }
-      rangeStart = "";
-      i++;
-      continue;
-    }
-    if (glob.startsWith("-]", i + 1)) {
-      ranges.push(braceEscape(c + "-"));
-      i += 2;
-      continue;
-    }
-    if (glob.startsWith("-", i + 1)) {
-      rangeStart = c;
-      i += 2;
-      continue;
-    }
-    ranges.push(braceEscape(c));
-    i++;
-  }
-  if (endPos < i) {
-    return ["", false, 0, false];
-  }
-  if (!ranges.length && !negs.length) {
-    return ["$.", false, glob.length - pos, true];
-  }
-  if (negs.length === 0 && ranges.length === 1 && /^\\?.$/.test(ranges[0]) && !negate) {
-    const r = ranges[0].length === 2 ? ranges[0].slice(-1) : ranges[0];
-    return [regexpEscape(r), false, endPos - pos, false];
-  }
-  const sranges = "[" + (negate ? "^" : "") + rangesToString(ranges) + "]";
-  const snegs = "[" + (negate ? "" : "^") + rangesToString(negs) + "]";
-  const comb = ranges.length && negs.length ? "(" + sranges + "|" + snegs + ")" : ranges.length ? sranges : snegs;
-  return [comb, uflag, endPos - pos, true];
-};
-
-// node_modules/minimatch/dist/esm/unescape.js
-var unescape = (s, { windowsPathsNoEscape = false, magicalBraces = true } = {}) => {
-  if (magicalBraces) {
-    return windowsPathsNoEscape ? s.replace(/\[([^/\\])\]/g, "$1") : s.replace(/((?!\\).|^)\[([^/\\])\]/g, "$1$2").replace(/\\([^/])/g, "$1");
-  }
-  return windowsPathsNoEscape ? s.replace(/\[([^/\\{}])\]/g, "$1") : s.replace(/((?!\\).|^)\[([^/\\{}])\]/g, "$1$2").replace(/\\([^/{}])/g, "$1");
-};
-
-// node_modules/minimatch/dist/esm/ast.js
-var _a;
-var types = /* @__PURE__ */ new Set(["!", "?", "+", "*", "@"]);
-var isExtglobType = (c) => types.has(c);
-var isExtglobAST = (c) => isExtglobType(c.type);
-var adoptionMap = /* @__PURE__ */ new Map([
-  ["!", ["@"]],
-  ["?", ["?", "@"]],
-  ["@", ["@"]],
-  ["*", ["*", "+", "?", "@"]],
-  ["+", ["+", "@"]]
-]);
-var adoptionWithSpaceMap = /* @__PURE__ */ new Map([
-  ["!", ["?"]],
-  ["@", ["?"]],
-  ["+", ["?", "*"]]
-]);
-var adoptionAnyMap = /* @__PURE__ */ new Map([
-  ["!", ["?", "@"]],
-  ["?", ["?", "@"]],
-  ["@", ["?", "@"]],
-  ["*", ["*", "+", "?", "@"]],
-  ["+", ["+", "@", "?", "*"]]
-]);
-var usurpMap = /* @__PURE__ */ new Map([
-  ["!", /* @__PURE__ */ new Map([["!", "@"]])],
-  [
-    "?",
-    /* @__PURE__ */ new Map([
-      ["*", "*"],
-      ["+", "*"]
-    ])
-  ],
-  [
-    "@",
-    /* @__PURE__ */ new Map([
-      ["!", "!"],
-      ["?", "?"],
-      ["@", "@"],
-      ["*", "*"],
-      ["+", "+"]
-    ])
-  ],
-  [
-    "+",
-    /* @__PURE__ */ new Map([
-      ["?", "*"],
-      ["*", "*"]
-    ])
-  ]
-]);
-var startNoTraversal = "(?!(?:^|/)\\.\\.?(?:$|/))";
-var startNoDot = "(?!\\.)";
-var addPatternStart = /* @__PURE__ */ new Set(["[", "."]);
-var justDots = /* @__PURE__ */ new Set(["..", "."]);
-var reSpecials = new Set("().*{}+?[]^$\\!");
-var regExpEscape = (s) => s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
-var qmark = "[^/]";
-var star = qmark + "*?";
-var starNoEmpty = qmark + "+?";
-var ID = 0;
-var AST = class {
-  type;
-  #root;
-  #hasMagic;
-  #uflag = false;
-  #parts = [];
-  #parent;
-  #parentIndex;
-  #negs;
-  #filledNegs = false;
-  #options;
-  #toString;
-  // set to true if it's an extglob with no children
-  // (which really means one child of '')
-  #emptyExt = false;
-  id = ++ID;
-  get depth() {
-    return (this.#parent?.depth ?? -1) + 1;
-  }
-  [/* @__PURE__ */ Symbol.for("nodejs.util.inspect.custom")]() {
-    return {
-      "@@type": "AST",
-      id: this.id,
-      type: this.type,
-      root: this.#root.id,
-      parent: this.#parent?.id,
-      depth: this.depth,
-      partsLength: this.#parts.length,
-      parts: this.#parts
-    };
-  }
-  constructor(type2, parent, options = {}) {
-    this.type = type2;
-    if (type2)
-      this.#hasMagic = true;
-    this.#parent = parent;
-    this.#root = this.#parent ? this.#parent.#root : this;
-    this.#options = this.#root === this ? options : this.#root.#options;
-    this.#negs = this.#root === this ? [] : this.#root.#negs;
-    if (type2 === "!" && !this.#root.#filledNegs)
-      this.#negs.push(this);
-    this.#parentIndex = this.#parent ? this.#parent.#parts.length : 0;
-  }
-  get hasMagic() {
-    if (this.#hasMagic !== void 0)
-      return this.#hasMagic;
-    for (const p of this.#parts) {
-      if (typeof p === "string")
-        continue;
-      if (p.type || p.hasMagic)
-        return this.#hasMagic = true;
-    }
-    return this.#hasMagic;
-  }
-  // reconstructs the pattern
-  toString() {
-    return this.#toString !== void 0 ? this.#toString : !this.type ? this.#toString = this.#parts.map((p) => String(p)).join("") : this.#toString = this.type + "(" + this.#parts.map((p) => String(p)).join("|") + ")";
-  }
-  #fillNegs() {
-    if (this !== this.#root)
-      throw new Error("should only call on root");
-    if (this.#filledNegs)
-      return this;
-    this.toString();
-    this.#filledNegs = true;
-    let n;
-    while (n = this.#negs.pop()) {
-      if (n.type !== "!")
-        continue;
-      let p = n;
-      let pp = p.#parent;
-      while (pp) {
-        for (let i = p.#parentIndex + 1; !pp.type && i < pp.#parts.length; i++) {
-          for (const part of n.#parts) {
-            if (typeof part === "string") {
-              throw new Error("string part in extglob AST??");
-            }
-            part.copyIn(pp.#parts[i]);
-          }
-        }
-        p = pp;
-        pp = p.#parent;
-      }
-    }
-    return this;
-  }
-  push(...parts) {
-    for (const p of parts) {
-      if (p === "")
-        continue;
-      if (typeof p !== "string" && !(p instanceof _a && p.#parent === this)) {
-        throw new Error("invalid part: " + p);
-      }
-      this.#parts.push(p);
-    }
-  }
-  toJSON() {
-    const ret = this.type === null ? this.#parts.slice().map((p) => typeof p === "string" ? p : p.toJSON()) : [this.type, ...this.#parts.map((p) => p.toJSON())];
-    if (this.isStart() && !this.type)
-      ret.unshift([]);
-    if (this.isEnd() && (this === this.#root || this.#root.#filledNegs && this.#parent?.type === "!")) {
-      ret.push({});
-    }
-    return ret;
-  }
-  isStart() {
-    if (this.#root === this)
-      return true;
-    if (!this.#parent?.isStart())
-      return false;
-    if (this.#parentIndex === 0)
-      return true;
-    const p = this.#parent;
-    for (let i = 0; i < this.#parentIndex; i++) {
-      const pp = p.#parts[i];
-      if (!(pp instanceof _a && pp.type === "!")) {
-        return false;
-      }
-    }
-    return true;
-  }
-  isEnd() {
-    if (this.#root === this)
-      return true;
-    if (this.#parent?.type === "!")
-      return true;
-    if (!this.#parent?.isEnd())
-      return false;
-    if (!this.type)
-      return this.#parent?.isEnd();
-    const pl = this.#parent ? this.#parent.#parts.length : 0;
-    return this.#parentIndex === pl - 1;
-  }
-  copyIn(part) {
-    if (typeof part === "string")
-      this.push(part);
-    else
-      this.push(part.clone(this));
-  }
-  clone(parent) {
-    const c = new _a(this.type, parent);
-    for (const p of this.#parts) {
-      c.copyIn(p);
-    }
-    return c;
-  }
-  static #parseAST(str2, ast, pos, opt, extDepth) {
-    const maxDepth = opt.maxExtglobRecursion ?? 2;
-    let escaping = false;
-    let inBrace = false;
-    let braceStart = -1;
-    let braceNeg = false;
-    if (ast.type === null) {
-      let i2 = pos;
-      let acc2 = "";
-      while (i2 < str2.length) {
-        const c = str2.charAt(i2++);
-        if (escaping || c === "\\") {
-          escaping = !escaping;
-          acc2 += c;
-          continue;
-        }
-        if (inBrace) {
-          if (i2 === braceStart + 1) {
-            if (c === "^" || c === "!") {
-              braceNeg = true;
-            }
-          } else if (c === "]" && !(i2 === braceStart + 2 && braceNeg)) {
-            inBrace = false;
-          }
-          acc2 += c;
-          continue;
-        } else if (c === "[") {
-          inBrace = true;
-          braceStart = i2;
-          braceNeg = false;
-          acc2 += c;
-          continue;
-        }
-        const doRecurse = !opt.noext && isExtglobType(c) && str2.charAt(i2) === "(" && extDepth <= maxDepth;
-        if (doRecurse) {
-          ast.push(acc2);
-          acc2 = "";
-          const ext2 = new _a(c, ast);
-          i2 = _a.#parseAST(str2, ext2, i2, opt, extDepth + 1);
-          ast.push(ext2);
-          continue;
-        }
-        acc2 += c;
-      }
-      ast.push(acc2);
-      return i2;
-    }
-    let i = pos + 1;
-    let part = new _a(null, ast);
-    const parts = [];
-    let acc = "";
-    while (i < str2.length) {
-      const c = str2.charAt(i++);
-      if (escaping || c === "\\") {
-        escaping = !escaping;
-        acc += c;
-        continue;
-      }
-      if (inBrace) {
-        if (i === braceStart + 1) {
-          if (c === "^" || c === "!") {
-            braceNeg = true;
-          }
-        } else if (c === "]" && !(i === braceStart + 2 && braceNeg)) {
-          inBrace = false;
-        }
-        acc += c;
-        continue;
-      } else if (c === "[") {
-        inBrace = true;
-        braceStart = i;
-        braceNeg = false;
-        acc += c;
-        continue;
-      }
-      const doRecurse = !opt.noext && isExtglobType(c) && str2.charAt(i) === "(" && /* c8 ignore start - the maxDepth is sufficient here */
-      (extDepth <= maxDepth || ast && ast.#canAdoptType(c));
-      if (doRecurse) {
-        const depthAdd = ast && ast.#canAdoptType(c) ? 0 : 1;
-        part.push(acc);
-        acc = "";
-        const ext2 = new _a(c, part);
-        part.push(ext2);
-        i = _a.#parseAST(str2, ext2, i, opt, extDepth + depthAdd);
-        continue;
-      }
-      if (c === "|") {
-        part.push(acc);
-        acc = "";
-        parts.push(part);
-        part = new _a(null, ast);
-        continue;
-      }
-      if (c === ")") {
-        if (acc === "" && ast.#parts.length === 0) {
-          ast.#emptyExt = true;
-        }
-        part.push(acc);
-        acc = "";
-        ast.push(...parts, part);
-        return i;
-      }
-      acc += c;
-    }
-    ast.type = null;
-    ast.#hasMagic = void 0;
-    ast.#parts = [str2.substring(pos - 1)];
-    return i;
-  }
-  #canAdoptWithSpace(child) {
-    return this.#canAdopt(child, adoptionWithSpaceMap);
-  }
-  #canAdopt(child, map2 = adoptionMap) {
-    if (!child || typeof child !== "object" || child.type !== null || child.#parts.length !== 1 || this.type === null) {
-      return false;
-    }
-    const gc = child.#parts[0];
-    if (!gc || typeof gc !== "object" || gc.type === null) {
-      return false;
-    }
-    return this.#canAdoptType(gc.type, map2);
-  }
-  #canAdoptType(c, map2 = adoptionAnyMap) {
-    return !!map2.get(this.type)?.includes(c);
-  }
-  #adoptWithSpace(child, index) {
-    const gc = child.#parts[0];
-    const blank = new _a(null, gc, this.options);
-    blank.#parts.push("");
-    gc.push(blank);
-    this.#adopt(child, index);
-  }
-  #adopt(child, index) {
-    const gc = child.#parts[0];
-    this.#parts.splice(index, 1, ...gc.#parts);
-    for (const p of gc.#parts) {
-      if (typeof p === "object")
-        p.#parent = this;
-    }
-    this.#toString = void 0;
-  }
-  #canUsurpType(c) {
-    const m = usurpMap.get(this.type);
-    return !!m?.has(c);
-  }
-  #canUsurp(child) {
-    if (!child || typeof child !== "object" || child.type !== null || child.#parts.length !== 1 || this.type === null || this.#parts.length !== 1) {
-      return false;
-    }
-    const gc = child.#parts[0];
-    if (!gc || typeof gc !== "object" || gc.type === null) {
-      return false;
-    }
-    return this.#canUsurpType(gc.type);
-  }
-  #usurp(child) {
-    const m = usurpMap.get(this.type);
-    const gc = child.#parts[0];
-    const nt = m?.get(gc.type);
-    if (!nt)
-      return false;
-    this.#parts = gc.#parts;
-    for (const p of this.#parts) {
-      if (typeof p === "object") {
-        p.#parent = this;
-      }
-    }
-    this.type = nt;
-    this.#toString = void 0;
-    this.#emptyExt = false;
-  }
-  static fromGlob(pattern, options = {}) {
-    const ast = new _a(null, void 0, options);
-    _a.#parseAST(pattern, ast, 0, options, 0);
-    return ast;
-  }
-  // returns the regular expression if there's magic, or the unescaped
-  // string if not.
-  toMMPattern() {
-    if (this !== this.#root)
-      return this.#root.toMMPattern();
-    const glob = this.toString();
-    const [re, body, hasMagic, uflag] = this.toRegExpSource();
-    const anyMagic = hasMagic || this.#hasMagic || this.#options.nocase && !this.#options.nocaseMagicOnly && glob.toUpperCase() !== glob.toLowerCase();
-    if (!anyMagic) {
-      return body;
-    }
-    const flags = (this.#options.nocase ? "i" : "") + (uflag ? "u" : "");
-    return Object.assign(new RegExp(`^${re}$`, flags), {
-      _src: re,
-      _glob: glob
-    });
-  }
-  get options() {
-    return this.#options;
-  }
-  // returns the string match, the regexp source, whether there's magic
-  // in the regexp (so a regular expression is required) and whether or
-  // not the uflag is needed for the regular expression (for posix classes)
-  // TODO: instead of injecting the start/end at this point, just return
-  // the BODY of the regexp, along with the start/end portions suitable
-  // for binding the start/end in either a joined full-path makeRe context
-  // (where we bind to (^|/), or a standalone matchPart context (where
-  // we bind to ^, and not /).  Otherwise slashes get duped!
-  //
-  // In part-matching mode, the start is:
-  // - if not isStart: nothing
-  // - if traversal possible, but not allowed: ^(?!\.\.?$)
-  // - if dots allowed or not possible: ^
-  // - if dots possible and not allowed: ^(?!\.)
-  // end is:
-  // - if not isEnd(): nothing
-  // - else: $
-  //
-  // In full-path matching mode, we put the slash at the START of the
-  // pattern, so start is:
-  // - if first pattern: same as part-matching mode
-  // - if not isStart(): nothing
-  // - if traversal possible, but not allowed: /(?!\.\.?(?:$|/))
-  // - if dots allowed or not possible: /
-  // - if dots possible and not allowed: /(?!\.)
-  // end is:
-  // - if last pattern, same as part-matching mode
-  // - else nothing
-  //
-  // Always put the (?:$|/) on negated tails, though, because that has to be
-  // there to bind the end of the negated pattern portion, and it's easier to
-  // just stick it in now rather than try to inject it later in the middle of
-  // the pattern.
-  //
-  // We can just always return the same end, and leave it up to the caller
-  // to know whether it's going to be used joined or in parts.
-  // And, if the start is adjusted slightly, can do the same there:
-  // - if not isStart: nothing
-  // - if traversal possible, but not allowed: (?:/|^)(?!\.\.?$)
-  // - if dots allowed or not possible: (?:/|^)
-  // - if dots possible and not allowed: (?:/|^)(?!\.)
-  //
-  // But it's better to have a simpler binding without a conditional, for
-  // performance, so probably better to return both start options.
-  //
-  // Then the caller just ignores the end if it's not the first pattern,
-  // and the start always gets applied.
-  //
-  // But that's always going to be $ if it's the ending pattern, or nothing,
-  // so the caller can just attach $ at the end of the pattern when building.
-  //
-  // So the todo is:
-  // - better detect what kind of start is needed
-  // - return both flavors of starting pattern
-  // - attach $ at the end of the pattern when creating the actual RegExp
-  //
-  // Ah, but wait, no, that all only applies to the root when the first pattern
-  // is not an extglob. If the first pattern IS an extglob, then we need all
-  // that dot prevention biz to live in the extglob portions, because eg
-  // +(*|.x*) can match .xy but not .yx.
-  //
-  // So, return the two flavors if it's #root and the first child is not an
-  // AST, otherwise leave it to the child AST to handle it, and there,
-  // use the (?:^|/) style of start binding.
-  //
-  // Even simplified further:
-  // - Since the start for a join is eg /(?!\.) and the start for a part
-  // is ^(?!\.), we can just prepend (?!\.) to the pattern (either root
-  // or start or whatever) and prepend ^ or / at the Regexp construction.
-  toRegExpSource(allowDot) {
-    const dot = allowDot ?? !!this.#options.dot;
-    if (this.#root === this) {
-      this.#flatten();
-      this.#fillNegs();
-    }
-    if (!isExtglobAST(this)) {
-      const noEmpty = this.isStart() && this.isEnd() && !this.#parts.some((s) => typeof s !== "string");
-      const src = this.#parts.map((p) => {
-        const [re, _, hasMagic, uflag] = typeof p === "string" ? _a.#parseGlob(p, this.#hasMagic, noEmpty) : p.toRegExpSource(allowDot);
-        this.#hasMagic = this.#hasMagic || hasMagic;
-        this.#uflag = this.#uflag || uflag;
-        return re;
-      }).join("");
-      let start3 = "";
-      if (this.isStart()) {
-        if (typeof this.#parts[0] === "string") {
-          const dotTravAllowed = this.#parts.length === 1 && justDots.has(this.#parts[0]);
-          if (!dotTravAllowed) {
-            const aps = addPatternStart;
-            const needNoTrav = (
-              // dots are allowed, and the pattern starts with [ or .
-              dot && aps.has(src.charAt(0)) || // the pattern starts with \., and then [ or .
-              src.startsWith("\\.") && aps.has(src.charAt(2)) || // the pattern starts with \.\., and then [ or .
-              src.startsWith("\\.\\.") && aps.has(src.charAt(4))
-            );
-            const needNoDot = !dot && !allowDot && aps.has(src.charAt(0));
-            start3 = needNoTrav ? startNoTraversal : needNoDot ? startNoDot : "";
-          }
-        }
-      }
-      let end = "";
-      if (this.isEnd() && this.#root.#filledNegs && this.#parent?.type === "!") {
-        end = "(?:$|\\/)";
-      }
-      const final2 = start3 + src + end;
-      return [
-        final2,
-        unescape(src),
-        this.#hasMagic = !!this.#hasMagic,
-        this.#uflag
-      ];
-    }
-    const repeated = this.type === "*" || this.type === "+";
-    const start2 = this.type === "!" ? "(?:(?!(?:" : "(?:";
-    let body = this.#partsToRegExp(dot);
-    if (this.isStart() && this.isEnd() && !body && this.type !== "!") {
-      const s = this.toString();
-      const me = this;
-      me.#parts = [s];
-      me.type = null;
-      me.#hasMagic = void 0;
-      return [s, unescape(this.toString()), false, false];
-    }
-    let bodyDotAllowed = !repeated || allowDot || dot || !startNoDot ? "" : this.#partsToRegExp(true);
-    if (bodyDotAllowed === body) {
-      bodyDotAllowed = "";
-    }
-    if (bodyDotAllowed) {
-      body = `(?:${body})(?:${bodyDotAllowed})*?`;
-    }
-    let final = "";
-    if (this.type === "!" && this.#emptyExt) {
-      final = (this.isStart() && !dot ? startNoDot : "") + starNoEmpty;
-    } else {
-      const close = this.type === "!" ? (
-        // !() must match something,but !(x) can match ''
-        "))" + (this.isStart() && !dot && !allowDot ? startNoDot : "") + star + ")"
-      ) : this.type === "@" ? ")" : this.type === "?" ? ")?" : this.type === "+" && bodyDotAllowed ? ")" : this.type === "*" && bodyDotAllowed ? `)?` : `)${this.type}`;
-      final = start2 + body + close;
-    }
-    return [
-      final,
-      unescape(body),
-      this.#hasMagic = !!this.#hasMagic,
-      this.#uflag
-    ];
-  }
-  #flatten() {
-    if (!isExtglobAST(this)) {
-      for (const p of this.#parts) {
-        if (typeof p === "object") {
-          p.#flatten();
-        }
-      }
-    } else {
-      let iterations = 0;
-      let done = false;
-      do {
-        done = true;
-        for (let i = 0; i < this.#parts.length; i++) {
-          const c = this.#parts[i];
-          if (typeof c === "object") {
-            c.#flatten();
-            if (this.#canAdopt(c)) {
-              done = false;
-              this.#adopt(c, i);
-            } else if (this.#canAdoptWithSpace(c)) {
-              done = false;
-              this.#adoptWithSpace(c, i);
-            } else if (this.#canUsurp(c)) {
-              done = false;
-              this.#usurp(c);
-            }
-          }
-        }
-      } while (!done && ++iterations < 10);
-    }
-    this.#toString = void 0;
-  }
-  #partsToRegExp(dot) {
-    return this.#parts.map((p) => {
-      if (typeof p === "string") {
-        throw new Error("string type in extglob ast??");
-      }
-      const [re, _, _hasMagic, uflag] = p.toRegExpSource(dot);
-      this.#uflag = this.#uflag || uflag;
-      return re;
-    }).filter((p) => !(this.isStart() && this.isEnd()) || !!p).join("|");
-  }
-  static #parseGlob(glob, hasMagic, noEmpty = false) {
-    let escaping = false;
-    let re = "";
-    let uflag = false;
-    let inStar = false;
-    for (let i = 0; i < glob.length; i++) {
-      const c = glob.charAt(i);
-      if (escaping) {
-        escaping = false;
-        re += (reSpecials.has(c) ? "\\" : "") + c;
-        continue;
-      }
-      if (c === "*") {
-        if (inStar)
-          continue;
-        inStar = true;
-        re += noEmpty && /^[*]+$/.test(glob) ? starNoEmpty : star;
-        hasMagic = true;
-        continue;
-      } else {
-        inStar = false;
-      }
-      if (c === "\\") {
-        if (i === glob.length - 1) {
-          re += "\\\\";
-        } else {
-          escaping = true;
-        }
-        continue;
-      }
-      if (c === "[") {
-        const [src, needUflag, consumed, magic] = parseClass(glob, i);
-        if (consumed) {
-          re += src;
-          uflag = uflag || needUflag;
-          i += consumed - 1;
-          hasMagic = hasMagic || magic;
-          continue;
-        }
-      }
-      if (c === "?") {
-        re += qmark;
-        hasMagic = true;
-        continue;
-      }
-      re += regExpEscape(c);
-    }
-    return [re, unescape(glob), !!hasMagic, uflag];
-  }
-};
-_a = AST;
-
-// node_modules/minimatch/dist/esm/escape.js
-var escape = (s, { windowsPathsNoEscape = false, magicalBraces = false } = {}) => {
-  if (magicalBraces) {
-    return windowsPathsNoEscape ? s.replace(/[?*()[\]{}]/g, "[$&]") : s.replace(/[?*()[\]\\{}]/g, "\\$&");
-  }
-  return windowsPathsNoEscape ? s.replace(/[?*()[\]]/g, "[$&]") : s.replace(/[?*()[\]\\]/g, "\\$&");
-};
-
-// node_modules/minimatch/dist/esm/index.js
-var minimatch = (p, pattern, options = {}) => {
-  assertValidPattern(pattern);
-  if (!options.nocomment && pattern.charAt(0) === "#") {
-    return false;
-  }
-  return new Minimatch(pattern, options).match(p);
-};
-var starDotExtRE = /^\*+([^+@!?*[(]*)$/;
-var starDotExtTest = (ext2) => (f) => !f.startsWith(".") && f.endsWith(ext2);
-var starDotExtTestDot = (ext2) => (f) => f.endsWith(ext2);
-var starDotExtTestNocase = (ext2) => {
-  ext2 = ext2.toLowerCase();
-  return (f) => !f.startsWith(".") && f.toLowerCase().endsWith(ext2);
-};
-var starDotExtTestNocaseDot = (ext2) => {
-  ext2 = ext2.toLowerCase();
-  return (f) => f.toLowerCase().endsWith(ext2);
-};
-var starDotStarRE = /^\*+\.\*+$/;
-var starDotStarTest = (f) => !f.startsWith(".") && f.includes(".");
-var starDotStarTestDot = (f) => f !== "." && f !== ".." && f.includes(".");
-var dotStarRE = /^\.\*+$/;
-var dotStarTest = (f) => f !== "." && f !== ".." && f.startsWith(".");
-var starRE = /^\*+$/;
-var starTest = (f) => f.length !== 0 && !f.startsWith(".");
-var starTestDot = (f) => f.length !== 0 && f !== "." && f !== "..";
-var qmarksRE = /^\?+([^+@!?*[(]*)?$/;
-var qmarksTestNocase = ([$0, ext2 = ""]) => {
-  const noext = qmarksTestNoExt([$0]);
-  if (!ext2)
-    return noext;
-  ext2 = ext2.toLowerCase();
-  return (f) => noext(f) && f.toLowerCase().endsWith(ext2);
-};
-var qmarksTestNocaseDot = ([$0, ext2 = ""]) => {
-  const noext = qmarksTestNoExtDot([$0]);
-  if (!ext2)
-    return noext;
-  ext2 = ext2.toLowerCase();
-  return (f) => noext(f) && f.toLowerCase().endsWith(ext2);
-};
-var qmarksTestDot = ([$0, ext2 = ""]) => {
-  const noext = qmarksTestNoExtDot([$0]);
-  return !ext2 ? noext : (f) => noext(f) && f.endsWith(ext2);
-};
-var qmarksTest = ([$0, ext2 = ""]) => {
-  const noext = qmarksTestNoExt([$0]);
-  return !ext2 ? noext : (f) => noext(f) && f.endsWith(ext2);
-};
-var qmarksTestNoExt = ([$0]) => {
-  const len = $0.length;
-  return (f) => f.length === len && !f.startsWith(".");
-};
-var qmarksTestNoExtDot = ([$0]) => {
-  const len = $0.length;
-  return (f) => f.length === len && f !== "." && f !== "..";
-};
-var defaultPlatform = typeof process === "object" && process ? typeof process.env === "object" && process.env && process.env.__MINIMATCH_TESTING_PLATFORM__ || process.platform : "posix";
-var path = {
-  win32: { sep: "\\" },
-  posix: { sep: "/" }
-};
-var sep2 = defaultPlatform === "win32" ? path.win32.sep : path.posix.sep;
-minimatch.sep = sep2;
-var GLOBSTAR = /* @__PURE__ */ Symbol("globstar **");
-minimatch.GLOBSTAR = GLOBSTAR;
-var qmark2 = "[^/]";
-var star2 = qmark2 + "*?";
-var twoStarDot = "(?:(?!(?:\\/|^)(?:\\.{1,2})($|\\/)).)*?";
-var twoStarNoDot = "(?:(?!(?:\\/|^)\\.).)*?";
-var filter = (pattern, options = {}) => (p) => minimatch(p, pattern, options);
-minimatch.filter = filter;
-var ext = (a, b = {}) => Object.assign({}, a, b);
-var defaults = (def) => {
-  if (!def || typeof def !== "object" || !Object.keys(def).length) {
-    return minimatch;
-  }
-  const orig = minimatch;
-  const m = (p, pattern, options = {}) => orig(p, pattern, ext(def, options));
-  return Object.assign(m, {
-    Minimatch: class Minimatch extends orig.Minimatch {
-      constructor(pattern, options = {}) {
-        super(pattern, ext(def, options));
-      }
-      static defaults(options) {
-        return orig.defaults(ext(def, options)).Minimatch;
-      }
-    },
-    AST: class AST extends orig.AST {
-      /* c8 ignore start */
-      constructor(type2, parent, options = {}) {
-        super(type2, parent, ext(def, options));
-      }
-      /* c8 ignore stop */
-      static fromGlob(pattern, options = {}) {
-        return orig.AST.fromGlob(pattern, ext(def, options));
-      }
-    },
-    unescape: (s, options = {}) => orig.unescape(s, ext(def, options)),
-    escape: (s, options = {}) => orig.escape(s, ext(def, options)),
-    filter: (pattern, options = {}) => orig.filter(pattern, ext(def, options)),
-    defaults: (options) => orig.defaults(ext(def, options)),
-    makeRe: (pattern, options = {}) => orig.makeRe(pattern, ext(def, options)),
-    braceExpand: (pattern, options = {}) => orig.braceExpand(pattern, ext(def, options)),
-    match: (list, pattern, options = {}) => orig.match(list, pattern, ext(def, options)),
-    sep: orig.sep,
-    GLOBSTAR
-  });
-};
-minimatch.defaults = defaults;
-var braceExpand = (pattern, options = {}) => {
-  assertValidPattern(pattern);
-  if (options.nobrace || !/\{(?:(?!\{).)*\}/.test(pattern)) {
-    return [pattern];
-  }
-  return expand2(pattern, { max: options.braceExpandMax });
-};
-minimatch.braceExpand = braceExpand;
-var makeRe = (pattern, options = {}) => new Minimatch(pattern, options).makeRe();
-minimatch.makeRe = makeRe;
-var match = (list, pattern, options = {}) => {
-  const mm = new Minimatch(pattern, options);
-  list = list.filter((f) => mm.match(f));
-  if (mm.options.nonull && !list.length) {
-    list.push(pattern);
-  }
-  return list;
-};
-minimatch.match = match;
-var globMagic = /[?*]|[+@!]\(.*?\)|\[|\]/;
-var regExpEscape2 = (s) => s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
-var Minimatch = class {
-  options;
-  set;
-  pattern;
-  windowsPathsNoEscape;
-  nonegate;
-  negate;
-  comment;
-  empty;
-  preserveMultipleSlashes;
-  partial;
-  globSet;
-  globParts;
-  nocase;
-  isWindows;
-  platform;
-  windowsNoMagicRoot;
-  maxGlobstarRecursion;
-  regexp;
-  constructor(pattern, options = {}) {
-    assertValidPattern(pattern);
-    options = options || {};
-    this.options = options;
-    this.maxGlobstarRecursion = options.maxGlobstarRecursion ?? 200;
-    this.pattern = pattern;
-    this.platform = options.platform || defaultPlatform;
-    this.isWindows = this.platform === "win32";
-    const awe = "allowWindowsEscape";
-    this.windowsPathsNoEscape = !!options.windowsPathsNoEscape || options[awe] === false;
-    if (this.windowsPathsNoEscape) {
-      this.pattern = this.pattern.replace(/\\/g, "/");
-    }
-    this.preserveMultipleSlashes = !!options.preserveMultipleSlashes;
-    this.regexp = null;
-    this.negate = false;
-    this.nonegate = !!options.nonegate;
-    this.comment = false;
-    this.empty = false;
-    this.partial = !!options.partial;
-    this.nocase = !!this.options.nocase;
-    this.windowsNoMagicRoot = options.windowsNoMagicRoot !== void 0 ? options.windowsNoMagicRoot : !!(this.isWindows && this.nocase);
-    this.globSet = [];
-    this.globParts = [];
-    this.set = [];
-    this.make();
-  }
-  hasMagic() {
-    if (this.options.magicalBraces && this.set.length > 1) {
-      return true;
-    }
-    for (const pattern of this.set) {
-      for (const part of pattern) {
-        if (typeof part !== "string")
-          return true;
-      }
-    }
-    return false;
-  }
-  debug(..._) {
-  }
-  make() {
-    const pattern = this.pattern;
-    const options = this.options;
-    if (!options.nocomment && pattern.charAt(0) === "#") {
-      this.comment = true;
-      return;
-    }
-    if (!pattern) {
-      this.empty = true;
-      return;
-    }
-    this.parseNegate();
-    this.globSet = [...new Set(this.braceExpand())];
-    if (options.debug) {
-      this.debug = (...args) => console.error(...args);
-    }
-    this.debug(this.pattern, this.globSet);
-    const rawGlobParts = this.globSet.map((s) => this.slashSplit(s));
-    this.globParts = this.preprocess(rawGlobParts);
-    this.debug(this.pattern, this.globParts);
-    let set2 = this.globParts.map((s, _, __) => {
-      if (this.isWindows && this.windowsNoMagicRoot) {
-        const isUNC = s[0] === "" && s[1] === "" && (s[2] === "?" || !globMagic.test(s[2])) && !globMagic.test(s[3]);
-        const isDrive = /^[a-z]:/i.test(s[0]);
-        if (isUNC) {
-          return [
-            ...s.slice(0, 4),
-            ...s.slice(4).map((ss) => this.parse(ss))
-          ];
-        } else if (isDrive) {
-          return [s[0], ...s.slice(1).map((ss) => this.parse(ss))];
-        }
-      }
-      return s.map((ss) => this.parse(ss));
-    });
-    this.debug(this.pattern, set2);
-    this.set = set2.filter((s) => s.indexOf(false) === -1);
-    if (this.isWindows) {
-      for (let i = 0; i < this.set.length; i++) {
-        const p = this.set[i];
-        if (p[0] === "" && p[1] === "" && this.globParts[i][2] === "?" && typeof p[3] === "string" && /^[a-z]:$/i.test(p[3])) {
-          p[2] = "?";
-        }
-      }
-    }
-    this.debug(this.pattern, this.set);
-  }
-  // various transforms to equivalent pattern sets that are
-  // faster to process in a filesystem walk.  The goal is to
-  // eliminate what we can, and push all ** patterns as far
-  // to the right as possible, even if it increases the number
-  // of patterns that we have to process.
-  preprocess(globParts) {
-    if (this.options.noglobstar) {
-      for (const partset of globParts) {
-        for (let j = 0; j < partset.length; j++) {
-          if (partset[j] === "**") {
-            partset[j] = "*";
-          }
-        }
-      }
-    }
-    const { optimizationLevel = 1 } = this.options;
-    if (optimizationLevel >= 2) {
-      globParts = this.firstPhasePreProcess(globParts);
-      globParts = this.secondPhasePreProcess(globParts);
-    } else if (optimizationLevel >= 1) {
-      globParts = this.levelOneOptimize(globParts);
-    } else {
-      globParts = this.adjascentGlobstarOptimize(globParts);
-    }
-    return globParts;
-  }
-  // just get rid of adjascent ** portions
-  adjascentGlobstarOptimize(globParts) {
-    return globParts.map((parts) => {
-      let gs = -1;
-      while (-1 !== (gs = parts.indexOf("**", gs + 1))) {
-        let i = gs;
-        while (parts[i + 1] === "**") {
-          i++;
-        }
-        if (i !== gs) {
-          parts.splice(gs, i - gs);
-        }
-      }
-      return parts;
-    });
-  }
-  // get rid of adjascent ** and resolve .. portions
-  levelOneOptimize(globParts) {
-    return globParts.map((parts) => {
-      parts = parts.reduce((set2, part) => {
-        const prev = set2[set2.length - 1];
-        if (part === "**" && prev === "**") {
-          return set2;
-        }
-        if (part === "..") {
-          if (prev && prev !== ".." && prev !== "." && prev !== "**") {
-            set2.pop();
-            return set2;
-          }
-        }
-        set2.push(part);
-        return set2;
-      }, []);
-      return parts.length === 0 ? [""] : parts;
-    });
-  }
-  levelTwoFileOptimize(parts) {
-    if (!Array.isArray(parts)) {
-      parts = this.slashSplit(parts);
-    }
-    let didSomething = false;
-    do {
-      didSomething = false;
-      if (!this.preserveMultipleSlashes) {
-        for (let i = 1; i < parts.length - 1; i++) {
-          const p = parts[i];
-          if (i === 1 && p === "" && parts[0] === "")
-            continue;
-          if (p === "." || p === "") {
-            didSomething = true;
-            parts.splice(i, 1);
-            i--;
-          }
-        }
-        if (parts[0] === "." && parts.length === 2 && (parts[1] === "." || parts[1] === "")) {
-          didSomething = true;
-          parts.pop();
-        }
-      }
-      let dd = 0;
-      while (-1 !== (dd = parts.indexOf("..", dd + 1))) {
-        const p = parts[dd - 1];
-        if (p && p !== "." && p !== ".." && p !== "**" && !(this.isWindows && /^[a-z]:$/i.test(p))) {
-          didSomething = true;
-          parts.splice(dd - 1, 2);
-          dd -= 2;
-        }
-      }
-    } while (didSomething);
-    return parts.length === 0 ? [""] : parts;
-  }
-  // First phase: single-pattern processing
-  // <pre> is 1 or more portions
-  // <rest> is 1 or more portions
-  // <p> is any portion other than ., .., '', or **
-  // <e> is . or ''
-  //
-  // **/.. is *brutal* for filesystem walking performance, because
-  // it effectively resets the recursive walk each time it occurs,
-  // and ** cannot be reduced out by a .. pattern part like a regexp
-  // or most strings (other than .., ., and '') can be.
-  //
-  // <pre>/**/../<p>/<p>/<rest> -> {<pre>/../<p>/<p>/<rest>,<pre>/**/<p>/<p>/<rest>}
-  // <pre>/<e>/<rest> -> <pre>/<rest>
-  // <pre>/<p>/../<rest> -> <pre>/<rest>
-  // **/**/<rest> -> **/<rest>
-  //
-  // **/*/<rest> -> */**/<rest> <== not valid because ** doesn't follow
-  // this WOULD be allowed if ** did follow symlinks, or * didn't
-  firstPhasePreProcess(globParts) {
-    let didSomething = false;
-    do {
-      didSomething = false;
-      for (let parts of globParts) {
-        let gs = -1;
-        while (-1 !== (gs = parts.indexOf("**", gs + 1))) {
-          let gss = gs;
-          while (parts[gss + 1] === "**") {
-            gss++;
-          }
-          if (gss > gs) {
-            parts.splice(gs + 1, gss - gs);
-          }
-          let next = parts[gs + 1];
-          const p = parts[gs + 2];
-          const p2 = parts[gs + 3];
-          if (next !== "..")
-            continue;
-          if (!p || p === "." || p === ".." || !p2 || p2 === "." || p2 === "..") {
-            continue;
-          }
-          didSomething = true;
-          parts.splice(gs, 1);
-          const other = parts.slice(0);
-          other[gs] = "**";
-          globParts.push(other);
-          gs--;
-        }
-        if (!this.preserveMultipleSlashes) {
-          for (let i = 1; i < parts.length - 1; i++) {
-            const p = parts[i];
-            if (i === 1 && p === "" && parts[0] === "")
-              continue;
-            if (p === "." || p === "") {
-              didSomething = true;
-              parts.splice(i, 1);
-              i--;
-            }
-          }
-          if (parts[0] === "." && parts.length === 2 && (parts[1] === "." || parts[1] === "")) {
-            didSomething = true;
-            parts.pop();
-          }
-        }
-        let dd = 0;
-        while (-1 !== (dd = parts.indexOf("..", dd + 1))) {
-          const p = parts[dd - 1];
-          if (p && p !== "." && p !== ".." && p !== "**") {
-            didSomething = true;
-            const needDot = dd === 1 && parts[dd + 1] === "**";
-            const splin = needDot ? ["."] : [];
-            parts.splice(dd - 1, 2, ...splin);
-            if (parts.length === 0)
-              parts.push("");
-            dd -= 2;
-          }
-        }
-      }
-    } while (didSomething);
-    return globParts;
-  }
-  // second phase: multi-pattern dedupes
-  // {<pre>/*/<rest>,<pre>/<p>/<rest>} -> <pre>/*/<rest>
-  // {<pre>/<rest>,<pre>/<rest>} -> <pre>/<rest>
-  // {<pre>/**/<rest>,<pre>/<rest>} -> <pre>/**/<rest>
-  //
-  // {<pre>/**/<rest>,<pre>/**/<p>/<rest>} -> <pre>/**/<rest>
-  // ^-- not valid because ** doens't follow symlinks
-  secondPhasePreProcess(globParts) {
-    for (let i = 0; i < globParts.length - 1; i++) {
-      for (let j = i + 1; j < globParts.length; j++) {
-        const matched = this.partsMatch(globParts[i], globParts[j], !this.preserveMultipleSlashes);
-        if (matched) {
-          globParts[i] = [];
-          globParts[j] = matched;
-          break;
-        }
-      }
-    }
-    return globParts.filter((gs) => gs.length);
-  }
-  partsMatch(a, b, emptyGSMatch = false) {
-    let ai = 0;
-    let bi = 0;
-    let result = [];
-    let which = "";
-    while (ai < a.length && bi < b.length) {
-      if (a[ai] === b[bi]) {
-        result.push(which === "b" ? b[bi] : a[ai]);
-        ai++;
-        bi++;
-      } else if (emptyGSMatch && a[ai] === "**" && b[bi] === a[ai + 1]) {
-        result.push(a[ai]);
-        ai++;
-      } else if (emptyGSMatch && b[bi] === "**" && a[ai] === b[bi + 1]) {
-        result.push(b[bi]);
-        bi++;
-      } else if (a[ai] === "*" && b[bi] && (this.options.dot || !b[bi].startsWith(".")) && b[bi] !== "**") {
-        if (which === "b")
-          return false;
-        which = "a";
-        result.push(a[ai]);
-        ai++;
-        bi++;
-      } else if (b[bi] === "*" && a[ai] && (this.options.dot || !a[ai].startsWith(".")) && a[ai] !== "**") {
-        if (which === "a")
-          return false;
-        which = "b";
-        result.push(b[bi]);
-        ai++;
-        bi++;
-      } else {
-        return false;
-      }
-    }
-    return a.length === b.length && result;
-  }
-  parseNegate() {
-    if (this.nonegate)
-      return;
-    const pattern = this.pattern;
-    let negate = false;
-    let negateOffset = 0;
-    for (let i = 0; i < pattern.length && pattern.charAt(i) === "!"; i++) {
-      negate = !negate;
-      negateOffset++;
-    }
-    if (negateOffset)
-      this.pattern = pattern.slice(negateOffset);
-    this.negate = negate;
-  }
-  // set partial to true to test if, for example,
-  // "/a/b" matches the start of "/*/b/*/d"
-  // Partial means, if you run out of file before you run
-  // out of pattern, then that's fine, as long as all
-  // the parts match.
-  matchOne(file, pattern, partial = false) {
-    let fileStartIndex = 0;
-    let patternStartIndex = 0;
-    if (this.isWindows) {
-      const fileDrive = typeof file[0] === "string" && /^[a-z]:$/i.test(file[0]);
-      const fileUNC = !fileDrive && file[0] === "" && file[1] === "" && file[2] === "?" && /^[a-z]:$/i.test(file[3]);
-      const patternDrive = typeof pattern[0] === "string" && /^[a-z]:$/i.test(pattern[0]);
-      const patternUNC = !patternDrive && pattern[0] === "" && pattern[1] === "" && pattern[2] === "?" && typeof pattern[3] === "string" && /^[a-z]:$/i.test(pattern[3]);
-      const fdi = fileUNC ? 3 : fileDrive ? 0 : void 0;
-      const pdi = patternUNC ? 3 : patternDrive ? 0 : void 0;
-      if (typeof fdi === "number" && typeof pdi === "number") {
-        const [fd, pd] = [
-          file[fdi],
-          pattern[pdi]
-        ];
-        if (fd.toLowerCase() === pd.toLowerCase()) {
-          pattern[pdi] = fd;
-          patternStartIndex = pdi;
-          fileStartIndex = fdi;
-        }
-      }
-    }
-    const { optimizationLevel = 1 } = this.options;
-    if (optimizationLevel >= 2) {
-      file = this.levelTwoFileOptimize(file);
-    }
-    if (pattern.includes(GLOBSTAR)) {
-      return this.#matchGlobstar(file, pattern, partial, fileStartIndex, patternStartIndex);
-    }
-    return this.#matchOne(file, pattern, partial, fileStartIndex, patternStartIndex);
-  }
-  #matchGlobstar(file, pattern, partial, fileIndex, patternIndex) {
-    const firstgs = pattern.indexOf(GLOBSTAR, patternIndex);
-    const lastgs = pattern.lastIndexOf(GLOBSTAR);
-    const [head, body, tail] = partial ? [
-      pattern.slice(patternIndex, firstgs),
-      pattern.slice(firstgs + 1),
-      []
-    ] : [
-      pattern.slice(patternIndex, firstgs),
-      pattern.slice(firstgs + 1, lastgs),
-      pattern.slice(lastgs + 1)
-    ];
-    if (head.length) {
-      const fileHead = file.slice(fileIndex, fileIndex + head.length);
-      if (!this.#matchOne(fileHead, head, partial, 0, 0)) {
-        return false;
-      }
-      fileIndex += head.length;
-      patternIndex += head.length;
-    }
-    let fileTailMatch = 0;
-    if (tail.length) {
-      if (tail.length + fileIndex > file.length)
-        return false;
-      let tailStart = file.length - tail.length;
-      if (this.#matchOne(file, tail, partial, tailStart, 0)) {
-        fileTailMatch = tail.length;
-      } else {
-        if (file[file.length - 1] !== "" || fileIndex + tail.length === file.length) {
-          return false;
-        }
-        tailStart--;
-        if (!this.#matchOne(file, tail, partial, tailStart, 0)) {
-          return false;
-        }
-        fileTailMatch = tail.length + 1;
-      }
-    }
-    if (!body.length) {
-      let sawSome = !!fileTailMatch;
-      for (let i2 = fileIndex; i2 < file.length - fileTailMatch; i2++) {
-        const f = String(file[i2]);
-        sawSome = true;
-        if (f === "." || f === ".." || !this.options.dot && f.startsWith(".")) {
-          return false;
-        }
-      }
-      return partial || sawSome;
-    }
-    const bodySegments = [[[], 0]];
-    let currentBody = bodySegments[0];
-    let nonGsParts = 0;
-    const nonGsPartsSums = [0];
-    for (const b of body) {
-      if (b === GLOBSTAR) {
-        nonGsPartsSums.push(nonGsParts);
-        currentBody = [[], 0];
-        bodySegments.push(currentBody);
-      } else {
-        currentBody[0].push(b);
-        nonGsParts++;
-      }
-    }
-    let i = bodySegments.length - 1;
-    const fileLength = file.length - fileTailMatch;
-    for (const b of bodySegments) {
-      b[1] = fileLength - (nonGsPartsSums[i--] + b[0].length);
-    }
-    return !!this.#matchGlobStarBodySections(file, bodySegments, fileIndex, 0, partial, 0, !!fileTailMatch);
-  }
-  // return false for "nope, not matching"
-  // return null for "not matching, cannot keep trying"
-  #matchGlobStarBodySections(file, bodySegments, fileIndex, bodyIndex, partial, globStarDepth, sawTail) {
-    const bs = bodySegments[bodyIndex];
-    if (!bs) {
-      for (let i = fileIndex; i < file.length; i++) {
-        sawTail = true;
-        const f = file[i];
-        if (f === "." || f === ".." || !this.options.dot && f.startsWith(".")) {
-          return false;
-        }
-      }
-      return sawTail;
-    }
-    const [body, after] = bs;
-    while (fileIndex <= after) {
-      const m = this.#matchOne(file.slice(0, fileIndex + body.length), body, partial, fileIndex, 0);
-      if (m && globStarDepth < this.maxGlobstarRecursion) {
-        const sub = this.#matchGlobStarBodySections(file, bodySegments, fileIndex + body.length, bodyIndex + 1, partial, globStarDepth + 1, sawTail);
-        if (sub !== false) {
-          return sub;
-        }
-      }
-      const f = file[fileIndex];
-      if (f === "." || f === ".." || !this.options.dot && f.startsWith(".")) {
-        return false;
-      }
-      fileIndex++;
-    }
-    return partial || null;
-  }
-  #matchOne(file, pattern, partial, fileIndex, patternIndex) {
-    let fi;
-    let pi;
-    let pl;
-    let fl;
-    for (fi = fileIndex, pi = patternIndex, fl = file.length, pl = pattern.length; fi < fl && pi < pl; fi++, pi++) {
-      this.debug("matchOne loop");
-      let p = pattern[pi];
-      let f = file[fi];
-      this.debug(pattern, p, f);
-      if (p === false || p === GLOBSTAR) {
-        return false;
-      }
-      let hit;
-      if (typeof p === "string") {
-        hit = f === p;
-        this.debug("string match", p, f, hit);
-      } else {
-        hit = p.test(f);
-        this.debug("pattern match", p, f, hit);
-      }
-      if (!hit)
-        return false;
-    }
-    if (fi === fl && pi === pl) {
-      return true;
-    } else if (fi === fl) {
-      return partial;
-    } else if (pi === pl) {
-      return fi === fl - 1 && file[fi] === "";
-    } else {
-      throw new Error("wtf?");
-    }
-  }
-  braceExpand() {
-    return braceExpand(this.pattern, this.options);
-  }
-  parse(pattern) {
-    assertValidPattern(pattern);
-    const options = this.options;
-    if (pattern === "**")
-      return GLOBSTAR;
-    if (pattern === "")
-      return "";
-    let m;
-    let fastTest = null;
-    if (m = pattern.match(starRE)) {
-      fastTest = options.dot ? starTestDot : starTest;
-    } else if (m = pattern.match(starDotExtRE)) {
-      fastTest = (options.nocase ? options.dot ? starDotExtTestNocaseDot : starDotExtTestNocase : options.dot ? starDotExtTestDot : starDotExtTest)(m[1]);
-    } else if (m = pattern.match(qmarksRE)) {
-      fastTest = (options.nocase ? options.dot ? qmarksTestNocaseDot : qmarksTestNocase : options.dot ? qmarksTestDot : qmarksTest)(m);
-    } else if (m = pattern.match(starDotStarRE)) {
-      fastTest = options.dot ? starDotStarTestDot : starDotStarTest;
-    } else if (m = pattern.match(dotStarRE)) {
-      fastTest = dotStarTest;
-    }
-    const re = AST.fromGlob(pattern, this.options).toMMPattern();
-    if (fastTest && typeof re === "object") {
-      Reflect.defineProperty(re, "test", { value: fastTest });
-    }
-    return re;
-  }
-  makeRe() {
-    if (this.regexp || this.regexp === false)
-      return this.regexp;
-    const set2 = this.set;
-    if (!set2.length) {
-      this.regexp = false;
-      return this.regexp;
-    }
-    const options = this.options;
-    const twoStar = options.noglobstar ? star2 : options.dot ? twoStarDot : twoStarNoDot;
-    const flags = new Set(options.nocase ? ["i"] : []);
-    let re = set2.map((pattern) => {
-      const pp = pattern.map((p) => {
-        if (p instanceof RegExp) {
-          for (const f of p.flags.split(""))
-            flags.add(f);
-        }
-        return typeof p === "string" ? regExpEscape2(p) : p === GLOBSTAR ? GLOBSTAR : p._src;
-      });
-      pp.forEach((p, i) => {
-        const next = pp[i + 1];
-        const prev = pp[i - 1];
-        if (p !== GLOBSTAR || prev === GLOBSTAR) {
-          return;
-        }
-        if (prev === void 0) {
-          if (next !== void 0 && next !== GLOBSTAR) {
-            pp[i + 1] = "(?:\\/|" + twoStar + "\\/)?" + next;
-          } else {
-            pp[i] = twoStar;
-          }
-        } else if (next === void 0) {
-          pp[i - 1] = prev + "(?:\\/|\\/" + twoStar + ")?";
-        } else if (next !== GLOBSTAR) {
-          pp[i - 1] = prev + "(?:\\/|\\/" + twoStar + "\\/)" + next;
-          pp[i + 1] = GLOBSTAR;
-        }
-      });
-      const filtered = pp.filter((p) => p !== GLOBSTAR);
-      if (this.partial && filtered.length >= 1) {
-        const prefixes = [];
-        for (let i = 1; i <= filtered.length; i++) {
-          prefixes.push(filtered.slice(0, i).join("/"));
-        }
-        return "(?:" + prefixes.join("|") + ")";
-      }
-      return filtered.join("/");
-    }).join("|");
-    const [open, close] = set2.length > 1 ? ["(?:", ")"] : ["", ""];
-    re = "^" + open + re + close + "$";
-    if (this.partial) {
-      re = "^(?:\\/|" + open + re.slice(1, -1) + close + ")$";
-    }
-    if (this.negate)
-      re = "^(?!" + re + ").+$";
-    try {
-      this.regexp = new RegExp(re, [...flags].join(""));
-    } catch {
-      this.regexp = false;
-    }
-    return this.regexp;
-  }
-  slashSplit(p) {
-    if (this.preserveMultipleSlashes) {
-      return p.split("/");
-    } else if (this.isWindows && /^\/\/[^/]+/.test(p)) {
-      return ["", ...p.split(/\/+/)];
-    } else {
-      return p.split(/\/+/);
-    }
-  }
-  match(f, partial = this.partial) {
-    this.debug("match", f, this.pattern);
-    if (this.comment) {
-      return false;
-    }
-    if (this.empty) {
-      return f === "";
-    }
-    if (f === "/" && partial) {
-      return true;
-    }
-    const options = this.options;
-    if (this.isWindows) {
-      f = f.split("\\").join("/");
-    }
-    const ff = this.slashSplit(f);
-    this.debug(this.pattern, "split", ff);
-    const set2 = this.set;
-    this.debug(this.pattern, "set", set2);
-    let filename = ff[ff.length - 1];
-    if (!filename) {
-      for (let i = ff.length - 2; !filename && i >= 0; i--) {
-        filename = ff[i];
-      }
-    }
-    for (const pattern of set2) {
-      let file = ff;
-      if (options.matchBase && pattern.length === 1) {
-        file = [filename];
-      }
-      const hit = this.matchOne(file, pattern, partial);
-      if (hit) {
-        if (options.flipNegate) {
-          return true;
-        }
-        return !this.negate;
-      }
-    }
-    if (options.flipNegate) {
-      return false;
-    }
-    return this.negate;
-  }
-  static defaults(def) {
-    return minimatch.defaults(def).Minimatch;
-  }
-};
-minimatch.AST = AST;
-minimatch.Minimatch = Minimatch;
-minimatch.escape = escape;
-minimatch.unescape = unescape;
-
-// src/io/translation-file-finder.ts
 var translationFileSchemes = {
   ini: (locale) => `**/*.${locale}.ini`,
   // PO files conventionally are named after the LOCALE itself (`en.po`,
@@ -44795,7 +44973,7 @@ async function findAllTranslationFiles(sourceLocale, options = {}) {
       const include2 = filesToInclude.some(
         (f) => f.toLowerCase() === filename.toLowerCase()
       );
-      (0, import_core8.debug)(`include=${include2}, ${filename}`);
+      (0, import_core9.debug)(`include=${include2}, ${filename}`);
       return include2;
     }
     return true;
@@ -44822,7 +45000,7 @@ async function findAllTranslationFiles(sourceLocale, options = {}) {
   });
   const files = await Promise.all(promises);
   const results = files.filter((file) => file.include && !file.isDirectory).map((file) => file.path).filter((path2) => include.length ? matchesAny(path2, include) : true).filter((path2) => !matchesAny(path2, exclude));
-  (0, import_core8.debug)(`Files to translate:
+  (0, import_core9.debug)(`Files to translate:
 	${results.join("\n	")}`);
   return {
     po: results.filter((f) => f.endsWith(".po")),
@@ -44842,9 +45020,9 @@ async function getFilesToInclude() {
         ...import_github.context.repo,
         ref: import_github.context.ref
       };
-      (0, import_core8.debug)(JSON.stringify(options));
+      (0, import_core9.debug)(JSON.stringify(options));
       const response = await octokit.rest.repos.getCommit(options);
-      (0, import_core8.debug)(JSON.stringify(response));
+      (0, import_core9.debug)(JSON.stringify(response));
       if (response.data && response.data.files) {
         const files = [
           ...new Set(
@@ -44854,32 +45032,50 @@ async function getFilesToInclude() {
             })
           )
         ];
-        (0, import_core8.debug)(`Files from trigger:
+        (0, import_core9.debug)(`Files from trigger:
 	${files.join("\n	")}`);
         return files;
       }
     } else {
-      (0, import_core8.debug)("Unable to get the GITHUB_TOKEN from the environment.");
+      (0, import_core9.debug)("Unable to get the GITHUB_TOKEN from the environment.");
     }
   } catch (error) {
     if (error instanceof Error) {
-      (0, import_core8.debug)(error.message);
+      (0, import_core9.debug)(error.message);
     } else {
-      (0, import_core8.debug)(`Unknown error: ${error}.`);
+      (0, import_core9.debug)(`Unknown error: ${error}.`);
     }
   }
   return [];
 }
 
 // src/resource-translator.ts
+var filterNoTranslateKeys = (text, patterns) => {
+  if (!patterns || patterns.length === 0) {
+    return { filtered: text, skipped: 0 };
+  }
+  const filtered = /* @__PURE__ */ new Map();
+  let skipped = 0;
+  for (const [key, value] of text) {
+    const matchesAny2 = patterns.some(
+      (p) => minimatch(key, p, { dot: true, nocase: false })
+    );
+    if (matchesAny2) {
+      skipped++;
+      continue;
+    }
+    filtered.set(key, value);
+  }
+  return { filtered, skipped };
+};
 async function start(inputs) {
   const failOnError = inputs.failOnError ?? true;
   const dryRun = inputs.dryRun ?? false;
   const reportError = (message) => {
     if (failOnError) {
-      (0, import_core9.setFailed)(message);
+      (0, import_core10.setFailed)(message);
     } else {
-      (0, import_core9.warning)(message);
+      (0, import_core10.warning)(message);
     }
   };
   try {
@@ -44904,7 +45100,7 @@ async function start(inputs) {
       }
       return true;
     }).sort((a, b) => naturalLanguageCompare(a, b));
-    (0, import_core9.info)(`Detected translation targets to: ${toLocales.join(", ")}`);
+    (0, import_core10.info)(`Detected translation targets to: ${toLocales.join(", ")}`);
     const translationFiles = await findAllTranslationFiles(
       inputs.sourceLocale,
       { include: inputs.include, exclude: inputs.exclude }
@@ -44927,14 +45123,14 @@ async function start(inputs) {
       allowFallback: inputs.allowFallback
     };
     for (const key of Object.keys(translationFiles)) {
-      (0, import_core9.debug)(`Iterating translationFiles keys, key: ${key}`);
+      (0, import_core10.debug)(`Iterating translationFiles keys, key: ${key}`);
       const kind = key;
       const files = translationFiles[kind];
       if (!files || !files.length) {
-        (0, import_core9.debug)(`For kind ${kind}, there are no translation files.`);
+        (0, import_core10.debug)(`For kind ${kind}, there are no translation files.`);
         continue;
       }
-      (0, import_core9.debug)(`Translation file parser kind: ${kind}`);
+      (0, import_core10.debug)(`Translation file parser kind: ${kind}`);
       const translationFileParser = translationFileParserFactory(kind);
       for (let index = 0; index < files.length; ++index) {
         const filePath = files[index];
@@ -44942,7 +45138,7 @@ async function start(inputs) {
           const fileContent = readFile(filePath);
           const parsedFile = await translationFileParser.parseFrom(fileContent);
           const translatableTextMap = translationFileParser.toTranslatableTextMap(parsedFile);
-          (0, import_core9.debug)(
+          (0, import_core10.debug)(
             `Translatable text:
  ${JSON.stringify(
               translatableTextMap,
@@ -44953,20 +45149,41 @@ async function start(inputs) {
             reportError("No translatable text to work with");
             continue;
           }
+          const { filtered, skipped } = filterNoTranslateKeys(
+            translatableTextMap.text,
+            inputs.noTranslatePatterns
+          );
+          if (skipped > 0) {
+            (0, import_core10.debug)(
+              `Skipped ${skipped} key(s) in ${filePath} due to noTranslatePatterns.`
+            );
+          }
+          if (filtered.size === 0) {
+            (0, import_core10.debug)(
+              `All translatable keys in ${filePath} were excluded by noTranslatePatterns; skipping translate call.`
+            );
+            continue;
+          }
           const resultSet = await translate(
             translatorResource,
             toLocales,
-            translatableTextMap.text,
-            filePath
+            filtered,
+            filePath,
+            {
+              protectPlaceholders: inputs.protectPlaceholders,
+              customPlaceholderPatterns: inputs.customPlaceholderPatterns,
+              maxRetries: inputs.maxRetries,
+              retryBackoffMs: inputs.retryBackoffMs
+            }
           );
-          (0, import_core9.debug)(`Translation result:
+          (0, import_core10.debug)(`Translation result:
  ${JSON.stringify(resultSet)}`);
           if (resultSet === void 0) {
             reportError("Unable to translate input text.");
             continue;
           }
-          const length = translatableTextMap.text.size;
-          (0, import_core9.debug)(
+          const length = filtered.size;
+          (0, import_core10.debug)(
             `Translation count: ${length}, toLocales size: ${toLocales.length}`
           );
           for (let i = 0; i < toLocales.length; ++i) {
@@ -44976,7 +45193,7 @@ async function start(inputs) {
               inputs.glossary
             );
             if (!translations) {
-              (0, import_core9.debug)(`Unable to find resulting translations for: ${locale}`);
+              (0, import_core10.debug)(`Unable to find resulting translations for: ${locale}`);
               continue;
             }
             const clone = await translationFileParser.parseFrom(fileContent);
@@ -44991,7 +45208,7 @@ async function start(inputs) {
             );
             const newPath = getLocaleName(filePath, locale);
             if (translatedFile && newPath) {
-              (0, import_core9.debug)(`The newPath: ${newPath}`);
+              (0, import_core10.debug)(`The newPath: ${newPath}`);
               if ((0, import_fs2.existsSync)(newPath)) {
                 summary.updatedFileCount++;
                 summary.updatedFileTranslations += length;
@@ -45000,13 +45217,13 @@ async function start(inputs) {
                 summary.newFileTranslations += length;
               }
               if (dryRun) {
-                (0, import_core9.info)(`[dry-run] Would write ${newPath}`);
+                (0, import_core10.info)(`[dry-run] Would write ${newPath}`);
               } else {
                 writeFile(newPath, translatedFile);
               }
             } else {
-              (0, import_core9.debug)(`The translatedFile value is ${translatedFile}`);
-              (0, import_core9.debug)(`The newPath would have been ${newPath}`);
+              (0, import_core10.debug)(`The translatedFile value is ${translatedFile}`);
+              (0, import_core10.debug)(`The newPath would have been ${newPath}`);
             }
           }
         } catch (error) {
@@ -45015,14 +45232,14 @@ async function start(inputs) {
         }
       }
     }
-    (0, import_core9.setOutput)("has-new-translations", summary.hasNewTranslations);
+    (0, import_core10.setOutput)("has-new-translations", summary.hasNewTranslations);
     const [title, details] = summarize(summary);
-    (0, import_core9.setOutput)("summary-title", title);
-    (0, import_core9.setOutput)("summary-details", details);
+    (0, import_core10.setOutput)("summary-title", title);
+    (0, import_core10.setOutput)("summary-details", details);
     try {
-      await import_core9.summary.addRaw(details).write();
+      await import_core10.summary.addRaw(details).write();
     } catch (error) {
-      (0, import_core9.debug)(
+      (0, import_core10.debug)(
         `Failed to write step summary: ${error instanceof Error ? error.message : String(error)}`
       );
     }
@@ -45039,9 +45256,9 @@ var run = async () => {
     await start(getInputs());
   } catch (error) {
     if (error instanceof Error) {
-      (0, import_core10.setFailed)(error);
+      (0, import_core11.setFailed)(error);
     } else {
-      (0, import_core10.setFailed)(`Unknown error: ${error}`);
+      (0, import_core11.setFailed)(`Unknown error: ${error}`);
     }
   }
 };

--- a/docs/src/pages/changelog.astro
+++ b/docs/src/pages/changelog.astro
@@ -37,6 +37,31 @@ import PageHero from "../components/PageHero.astro";
         >from=&lt;locale&gt;</code
       > so short strings aren't autodetected.
     </li>
+    <li>
+      <strong>Resilience:</strong> automatic retry on transient HTTP responses
+      (408, 425, 429, 500, 502, 503, 504) honoring Azure's
+      <code>Retry-After</code> header — falls back to jittered exponential
+      backoff when absent. Tunable via <code>maxRetries</code> and
+      <code>retryBackoffMs</code>. <em>Closes #46.</em>
+    </li>
+    <li>
+      <strong>Placeholder protection:</strong> tokens like
+      <code>&#123;&#123;name&#125;&#125;</code>, <code>$&#123;var&#125;</code>,
+      <code>&#123;0&#125;</code>, <code>&#123;0:N2&#125;</code>, <code>%s</code>,
+      <code>%1$s</code> and HTML entities are wrapped in sentinels before
+      translation and restored afterward, so Translator stops mangling
+      i18next/Mustache/Handlebars/.NET/printf placeholders. Toggle via
+      <code>protectPlaceholders</code>; extend with
+      <code>customPlaceholderPatterns</code>. <em>Tightens #16.</em>
+    </li>
+    <li>
+      <strong>Per-key opt-out:</strong> new
+      <code>noTranslatePatterns</code> input drops matching keys from the
+      Translator request entirely (preserves source values for brand names,
+      error codes, etc.). Matches glob patterns against parser-level keys
+      (JSON dotted path, RESX <code>name</code>, PO <code>msgid</code>, XLIFF
+      unit <code>id</code>, INI/restext key). <em>Closes #35.</em>
+    </li>
     <li>Repo-level config via <code>.github/resource-translator.yml</code>.</li>
     <li>Glossary support, step summary via <code>core.summary</code>.</li>
     <li>esbuild bundler, ESLint 9 flat config, Prettier, EditorConfig.</li>

--- a/docs/src/pages/configuration.astro
+++ b/docs/src/pages/configuration.astro
@@ -29,6 +29,25 @@ profanityMarker: Asterisk        # Asterisk | Tag (only when profanityAction == 
 allowFallback: true              # false fails when the categoryId has no deployment
 
 apiVersion: "3.0"
+
+# Resilience — Translator returns 429 under load. Defaults are usually
+# fine; tune only if your runs are large enough to hit them.
+maxRetries: 5
+retryBackoffMs: 30000             # cap on any single backoff sleep (ms)
+
+# Placeholder protection. ON by default — wraps tokens like {{name}},
+# {0}, %s, \${var} into sentinels before translation and restores them
+# on the way back. Set false only when source intentionally contains
+# placeholder-shaped literals.
+protectPlaceholders: true
+customPlaceholderPatterns:
+  - "<<.+?>>"                     # any extra token syntax you use
+
+# Per-key opt-out. Keys matching any glob are dropped from the request
+# and pass through with the source value preserved.
+noTranslatePatterns:
+  - "errors.code.*"
+  - "brands.*"
 `;
 ---
 
@@ -64,6 +83,11 @@ apiVersion: "3.0"
       <tr><td><code>profanityMarker</code></td><td><code>"Asterisk"</code> | <code>"Tag"</code></td><td>Only meaningful when <code>profanityAction</code> is <code>"Marked"</code>.</td></tr>
       <tr><td><code>allowFallback</code></td><td>boolean</td><td>Set to <code>false</code> to fail the translation when your <code>categoryId</code> has no deployment for a target locale instead of falling back to the general model.</td></tr>
       <tr><td><code>apiVersion</code></td><td>string</td><td>Translator REST API version. Defaults to <code>3.0</code>.</td></tr>
+      <tr><td><code>maxRetries</code></td><td>integer</td><td>Maximum retry attempts on transient HTTP responses (408, 425, 429, 500, 502, 503, 504). Defaults to <code>5</code>. Total HTTP calls per request is <code>1 + maxRetries</code>.</td></tr>
+      <tr><td><code>retryBackoffMs</code></td><td>integer</td><td>Cap (ms) on any single backoff sleep. Defaults to <code>30000</code>. Azure's <code>Retry-After</code> header is honored exactly when present; otherwise jittered exponential backoff is used, capped at this value.</td></tr>
+      <tr><td><code>protectPlaceholders</code></td><td>boolean</td><td>Defaults to <code>true</code>. When on, tokens like <code>&#123;&#123;name&#125;&#125;</code>, <code>$&#123;var&#125;</code>, <code>&#123;0&#125;</code>, <code>&#123;0:N2&#125;</code>, <code>%s</code>, <code>%1$s</code> and HTML entities are replaced with sentinel tokens before translation and restored afterward. Disable only when source intentionally contains placeholder-shaped literals.</td></tr>
+      <tr><td><code>customPlaceholderPatterns</code></td><td>string[]</td><td>Extra regex patterns (without delimiters) added to the default placeholder set, e.g. <code>&lt;&lt;.+?&gt;&gt;</code> for custom token syntax. Invalid regexes are ignored.</td></tr>
+      <tr><td><code>noTranslatePatterns</code></td><td>string[]</td><td>Glob patterns matched against parser-level keys (JSON dotted path, RESX <code>name</code>, PO <code>msgid</code>, XLIFF unit <code>id</code>, INI/restext key). Matching keys are dropped from the request and pass through with their source value preserved.</td></tr>
     </tbody>
   </table>
 

--- a/docs/src/pages/inputs.astro
+++ b/docs/src/pages/inputs.astro
@@ -63,6 +63,25 @@ import PageHero from "../components/PageHero.astro";
     </tbody>
   </table>
 
+  <h2>Resilience &amp; placeholder protection</h2>
+  <p>
+    These inputs control how the action behaves when Translator throttles your
+    request and how it shields placeholder tokens like <code>&#123;&#123;name&#125;&#125;</code> or
+    <code>&#123;0&#125;</code> from being mangled during translation.
+  </p>
+  <table>
+    <thead>
+      <tr><th>Name</th><th>Default</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><code>maxRetries</code></td><td><code>5</code></td><td>Maximum retry attempts on transient HTTP responses (408, 425, 429, 500, 502, 503, 504). The total number of HTTP calls per request is <code>1 + maxRetries</code>.</td></tr>
+      <tr><td><code>retryBackoffMs</code></td><td><code>30000</code></td><td>Cap (in milliseconds) on any single backoff sleep. The action honors Azure's <code>Retry-After</code> response header exactly when present; otherwise it uses jittered exponential backoff capped at this value.</td></tr>
+      <tr><td><code>protectPlaceholders</code></td><td><code>true</code></td><td>When <code>true</code> (default), placeholders such as <code>&#123;&#123;name&#125;&#125;</code>, <code>$&#123;var&#125;</code>, <code>&#123;0&#125;</code>, <code>&#123;0:N2&#125;</code>, <code>%s</code>, <code>%1$s</code> and HTML entities are replaced with sentinel tokens before translation and restored afterward. Disable only when your source intentionally contains literal placeholder-shaped text that should be translated.</td></tr>
+      <tr><td><code>customPlaceholderPatterns</code></td><td><em>none</em></td><td>Newline-separated regexes (without delimiters) added to the default placeholder set, e.g. <code>&lt;&lt;.+?&gt;&gt;</code> for custom token syntax.</td></tr>
+      <tr><td><code>noTranslatePatterns</code></td><td><em>none</em></td><td>Newline-separated glob patterns matched against parser-level keys (JSON dotted path, RESX <code>name</code>, PO <code>msgid</code>, XLIFF unit <code>id</code>, INI/restext key). Matching keys are dropped from the Translator request and pass through with their source value preserved.</td></tr>
+    </tbody>
+  </table>
+
   <h2>Outputs</h2>
   <table>
     <thead>

--- a/src/action/get-inputs.ts
+++ b/src/action/get-inputs.ts
@@ -33,6 +33,11 @@ export const getInputs = (): Inputs => {
       PROFANITY_MARKERS,
     ),
     allowFallback: getOptionalBooleanOrUndefined("allowFallback"),
+    noTranslatePatterns: getMultilineList("noTranslatePatterns"),
+    protectPlaceholders: getOptionalBooleanOrUndefined("protectPlaceholders"),
+    customPlaceholderPatterns: getMultilineList("customPlaceholderPatterns"),
+    maxRetries: getOptionalInt("maxRetries"),
+    retryBackoffMs: getOptionalInt("retryBackoffMs"),
     dryRun: getOptionalBoolean("dryRun", false),
     failOnError: getOptionalBoolean("failOnError", true),
   };
@@ -140,6 +145,23 @@ const getMultilineList = (name: string): string[] | undefined => {
     .map((v) => v.trim())
     .filter(Boolean);
   return list.length ? list : undefined;
+};
+
+/**
+ * Reads a non-negative integer input. Returns `undefined` when the input is
+ * empty so the downstream consumer can apply its own default. Invalid
+ * non-empty values throw to fail fast on misconfiguration.
+ */
+const getOptionalInt = (name: string): number | undefined => {
+  const raw = getInput(name)?.trim();
+  if (!raw) return undefined;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(
+      `Input '${name}' must be a non-negative integer. Got: '${raw}'.`,
+    );
+  }
+  return n;
 };
 
 /**

--- a/src/action/inputs.ts
+++ b/src/action/inputs.ts
@@ -55,6 +55,49 @@ export interface RepoConfig {
    * default applies (allow fallback).
    */
   allowFallback?: boolean;
+
+  /**
+   * Newline-separated glob patterns matched against parser key paths
+   * (`name` for resx, `msgid` for po, unit `id` for xliff, `[--]`-joined
+   * paths for json, raw key for ini/restext). Matching keys are kept
+   * verbatim from the source and never sent to Translator. Useful for
+   * brand names, technical IDs, or any value where machine translation
+   * would corrupt meaning.
+   */
+  noTranslatePatterns?: string[];
+
+  /**
+   * When true (default), wrap common placeholder tokens (`{{name}}`, `{0}`,
+   * `%s`, `${var}`, ...) in stable sentinels before sending text to
+   * Translator and unwrap them afterwards. This prevents Azure from
+   * rearranging or translating placeholder names, which otherwise breaks
+   * runtime formatting in localized output. Disable only if your source
+   * text explicitly contains literal sequences that look like placeholders.
+   */
+  protectPlaceholders?: boolean;
+
+  /**
+   * Optional extra regex patterns (raw source strings, no surrounding
+   * slashes) added to the placeholder protector. Each pattern is compiled
+   * with the global flag if it is not already supplied. Invalid regex
+   * patterns are skipped silently.
+   */
+  customPlaceholderPatterns?: string[];
+
+  /**
+   * Maximum number of additional retry attempts on transient Translator
+   * failures (HTTP 408, 425, 429, 500, 502, 503, 504). The total number of
+   * HTTP calls per request is `1 + maxRetries`. Defaults to 5.
+   */
+  maxRetries?: number;
+
+  /**
+   * Cap (ms) on any single backoff sleep between retries. The Azure-
+   * supplied `Retry-After` header is honored exactly when present;
+   * otherwise an exponentially growing jittered sleep is used, capped at
+   * this value. Defaults to 30000ms (30s).
+   */
+  retryBackoffMs?: number;
 }
 
 /** Closed set of valid `textType` values for runtime validation. */

--- a/src/action/load-config.ts
+++ b/src/action/load-config.ts
@@ -80,6 +80,14 @@ const normalizeRepoConfig = (raw: RepoConfig): RepoConfig => {
     return undefined;
   };
 
+  const nonNegativeInt = (value: unknown): number | undefined => {
+    if (value === undefined || value === null || value === "") return undefined;
+    const n =
+      typeof value === "number" ? value : Number.parseInt(String(value), 10);
+    if (!Number.isFinite(n) || n < 0) return undefined;
+    return n;
+  };
+
   return {
     sourceLocale:
       typeof raw.sourceLocale === "string" ? raw.sourceLocale : undefined,
@@ -102,6 +110,11 @@ const normalizeRepoConfig = (raw: RepoConfig): RepoConfig => {
       PROFANITY_MARKERS,
     ),
     allowFallback: booleanOrUndefined(raw.allowFallback),
+    noTranslatePatterns: stringList(raw.noTranslatePatterns),
+    protectPlaceholders: booleanOrUndefined(raw.protectPlaceholders),
+    customPlaceholderPatterns: stringList(raw.customPlaceholderPatterns),
+    maxRetries: nonNegativeInt(raw.maxRetries),
+    retryBackoffMs: nonNegativeInt(raw.retryBackoffMs),
   };
 };
 
@@ -126,6 +139,11 @@ export const mergeInputsAndConfig = <T extends RepoConfig>(
     "profanityAction",
     "profanityMarker",
     "allowFallback",
+    "noTranslatePatterns",
+    "protectPlaceholders",
+    "customPlaceholderPatterns",
+    "maxRetries",
+    "retryBackoffMs",
   ];
   for (const key of keys) {
     if (merged[key] === undefined || isEmpty(merged[key])) {

--- a/src/api/translation-api.ts
+++ b/src/api/translation-api.ts
@@ -10,7 +10,24 @@ import {
 } from "../abstractions/translation-results";
 import { TranslatorResource } from "../abstractions/translator-resource";
 import { toResultSet } from "../helpers/api-result-set-mapper";
+import { protect, restore } from "../helpers/placeholders";
+import { isTransientStatus, retryablePost } from "../helpers/retry";
 import { batch, chunk } from "../helpers/utils";
+
+/** Translate-time options that are NOT properties of the Translator
+ *  resource itself (auth, region, category) — these belong to the action's
+ *  per-call behavior (retries, placeholder protection, etc). Kept separate
+ *  so the resource abstraction stays a pure config-of-Azure value. */
+export interface TranslateOptions {
+  /** Wrap placeholders in sentinels before sending to Translator. */
+  protectPlaceholders?: boolean;
+  /** Extra regex patterns appended to the placeholder protector. */
+  customPlaceholderPatterns?: readonly string[];
+  /** Max retry attempts on transient Translator failures. */
+  maxRetries?: number;
+  /** Cap (ms) on any single backoff sleep. */
+  retryBackoffMs?: number;
+}
 
 // The Translator "languages" lookup is anonymous and lives on the global
 // Microsoft endpoint regardless of how the user has configured their
@@ -71,6 +88,7 @@ export const translate = async (
   toLocales: string[],
   translatableText: Map<string, string>,
   filePath: string,
+  options?: TranslateOptions,
 ): Promise<TranslationResultSet | undefined> => {
   try {
     // Current Azure Translator API rate limit
@@ -92,9 +110,28 @@ export const translate = async (
       return undefined;
     }
 
-    const data = [...translatableText.values()].map((value) => ({
-      text: value,
-    }));
+    // Default placeholder protection ON. Disable explicitly via input only
+    // when the source intentionally contains literal `{{name}}`-shaped text
+    // that should be translated as-is.
+    const protectEnabled = options?.protectPlaceholders !== false;
+
+    // Per-call sentinel maps. We protect each text individually so the
+    // sentinel counter cannot collide across keys, and we keep the order in
+    // lockstep with `translatableText.values()` (the input array order is
+    // the same order Translator preserves in its response).
+    const sentinelMaps: Array<Map<string, string>> = [];
+    const data = [...translatableText.values()].map((value) => {
+      if (!protectEnabled) {
+        sentinelMaps.push(new Map());
+        return { text: value };
+      }
+      const { protected: p, tokens } = protect(
+        value,
+        options?.customPlaceholderPatterns,
+      );
+      sentinelMaps.push(tokens);
+      return { text: p };
+    });
 
     const apiVersion = translatorResource.apiVersion ?? "3.0";
     const client = buildClient(translatorResource.endpoint, apiVersion);
@@ -107,6 +144,10 @@ export const translate = async (
         : [data];
 
     let results: TranslationResults = [];
+    // Track which sentinel map to use per response row. Translator preserves
+    // the order of inputs across the response, so the i-th batch row maps
+    // back to the i-th sentinel map across the entire input.
+    let nextSentinelOffset = 0;
     for (let i = 0; i < batchedData.length; i++) {
       const dataBatch = batchedData[i];
       const batchCharacters = JSON.stringify(dataBatch).length;
@@ -116,6 +157,16 @@ export const translate = async (
         localesBatchSize < localeCount
           ? chunk(toLocales, localesBatchSize)
           : [toLocales];
+
+      // Sentinel maps for THIS data batch (positional alignment with
+      // dataBatch). Same maps are reused across every locale-batch since
+      // Translator returns the per-locale translation rows in the same
+      // input order.
+      const sentinelsForBatch = sentinelMaps.slice(
+        nextSentinelOffset,
+        nextSentinelOffset + dataBatch.length,
+      );
+      nextSentinelOffset += dataBatch.length;
 
       for (let j = 0; j < batchedLocales.length; j++) {
         const locales = batchedLocales[j];
@@ -155,11 +206,19 @@ export const translate = async (
           }),
         };
 
-        const response = await client.path("/translate").post({
-          body: dataBatch,
-          headers,
-          queryParameters,
-        });
+        const response = await retryablePost(
+          () =>
+            client.path("/translate").post({
+              body: dataBatch,
+              headers,
+              queryParameters,
+            }),
+          (resp) => isUnexpected(resp) && isTransientStatus(resp.status),
+          {
+            maxRetries: options?.maxRetries,
+            retryBackoffMs: options?.retryBackoffMs,
+          },
+        );
 
         if (isUnexpected(response)) {
           const azureError = response.body?.error;
@@ -176,6 +235,22 @@ export const translate = async (
         }
 
         const responseData = response.body as unknown as TranslationResult[];
+
+        // Restore protected placeholders in every translation row. Each
+        // response row corresponds to one input row in the SAME position
+        // (Azure preserves input order), so the sentinel map at index k of
+        // sentinelsForBatch applies to responseData[k].
+        if (protectEnabled) {
+          responseData.forEach((row, k) => {
+            const tokens = sentinelsForBatch[k];
+            if (!tokens || tokens.size === 0) return;
+            row.translations = row.translations.map((t) => ({
+              ...t,
+              text: restore(t.text, tokens),
+            }));
+          });
+        }
+
         debug(
           `Data batch ${i + 1}, Locales batch ${
             j + 1

--- a/src/helpers/placeholders.ts
+++ b/src/helpers/placeholders.ts
@@ -1,0 +1,107 @@
+/**
+ * Placeholder protection — wraps tokens like `{{name}}`, `{0}`, `%s`, `${var}`
+ * into stable sentinels before sending text to Translator and unwraps them on
+ * the way back out. Without this, Azure Translator regularly rewrites these
+ * tokens (rearranging arg numbers, translating placeholder *names*, splitting
+ * `%1$s` across words, ...) and the resulting localized strings break runtime
+ * formatting in any language other than English.
+ *
+ * The sentinel uses a long ASCII run that survives every Translator language
+ * unchanged and never collides with real source content. It is intentionally
+ * NOT a Unicode private-use codepoint or control character — Azure normalizes
+ * many of those away.
+ */
+
+/**
+ * Default placeholder patterns. Order matters — more specific matches (e.g.
+ * printf `%1$s`) come before less specific ones (e.g. plain `%s`) so the
+ * larger token wins.
+ */
+export const DEFAULT_PLACEHOLDER_PATTERNS: readonly RegExp[] = [
+  // i18next / Mustache / Handlebars: {{name}} or {{ name }}
+  /\{\{\s*[\w.\-:|]+\s*\}\}/g,
+  // ES template literals / shell-ish: ${name}
+  /\$\{[\w.-]+\}/g,
+  // .NET / C# / Java composite formatting: {0}, {0:format}, {name}, {name,10:N2}
+  /\{\d+(?:[,:][^{}]*)?\}/g,
+  /\{[A-Za-z_][\w.-]*(?:[,:][^{}]*)?\}/g,
+  // printf positional & flagged: %1$s, %2$d, %.2f, %-10s
+  /%\d+\$[#\-+ 0,]*\d*(?:\.\d+)?[diouxXeEfgGsScCpn%]/g,
+  /%[#\-+ 0,]*\d*(?:\.\d+)?[diouxXeEfgGsScCpn%]/g,
+  // XML/HTML-ish entities the user pasted as literal source text (e.g. &nbsp;)
+  /&[a-zA-Z]+;/g,
+];
+
+const TOKEN_PREFIX = "RTKEEP";
+const TOKEN_RE = /RTKEEP(\d{6})/g;
+
+export interface ProtectResult {
+  /** Text with placeholders replaced by sentinel tokens. */
+  protected: string;
+  /** Map of sentinel token -> original placeholder text. */
+  tokens: Map<string, string>;
+}
+
+const compileExtraPatterns = (customPatterns?: readonly string[]): RegExp[] => {
+  if (!customPatterns?.length) return [];
+  const compiled: RegExp[] = [];
+  for (const raw of customPatterns) {
+    const trimmed = raw?.trim();
+    if (!trimmed) continue;
+    try {
+      // Always force the global flag so `replace(re, fn)` walks every match.
+      compiled.push(
+        new RegExp(trimmed, trimmed.startsWith("/") ? undefined : "g"),
+      );
+    } catch {
+      // Skip invalid user-supplied regexes silently — they are surfaced as
+      // warnings during input validation, so by the time we get here we just
+      // want translation to still proceed.
+    }
+  }
+  return compiled;
+};
+
+/**
+ * Replace any placeholder occurrences in `text` with stable sentinel tokens.
+ * Returns the protected text plus a map you can later pass to `restore`.
+ *
+ * @example
+ *   const { protected: p, tokens } = protect("Hello {{name}}!");
+ *   // p === "Hello RTKEEP000001!"
+ *   restore("Bonjour RTKEEP000001!", tokens) === "Bonjour {{name}}!"
+ */
+export const protect = (
+  text: string,
+  customPatterns?: readonly string[],
+): ProtectResult => {
+  const tokens = new Map<string, string>();
+  if (!text) return { protected: text, tokens };
+
+  const patterns = [
+    ...DEFAULT_PLACEHOLDER_PATTERNS,
+    ...compileExtraPatterns(customPatterns),
+  ];
+
+  let next = text;
+  let counter = 0;
+  for (const re of patterns) {
+    next = next.replace(re, (match) => {
+      const token = `${TOKEN_PREFIX}${String(counter++).padStart(6, "0")}`;
+      tokens.set(token, match);
+      return token;
+    });
+  }
+
+  return { protected: next, tokens };
+};
+
+/**
+ * Restore previously-protected placeholders. Robust against minor mangling:
+ * matches the sentinel pattern with a regex (case-insensitive) so a
+ * Translator that lower-cases the string still round-trips correctly.
+ */
+export const restore = (text: string, tokens: Map<string, string>): string => {
+  if (!text || tokens.size === 0) return text;
+  return text.replace(TOKEN_RE, (match) => tokens.get(match) ?? match);
+};

--- a/src/helpers/retry.ts
+++ b/src/helpers/retry.ts
@@ -1,0 +1,146 @@
+import { warning } from "@actions/core";
+
+/**
+ * Status codes that can be retried. 408 (request timeout), 425 (too early),
+ * 429 (rate limited) and the standard "transient server failure" 5xx codes
+ * all map to a backoff-and-retry policy. Any other unexpected status flows
+ * straight back to the caller as a permanent failure.
+ */
+const TRANSIENT_STATUSES = new Set<number>([408, 425, 429, 500, 502, 503, 504]);
+
+export interface RetryOptions {
+  /**
+   * Maximum number of additional attempts after the initial call. The total
+   * number of HTTP calls per request is `1 + maxRetries`. Defaults to 5.
+   */
+  maxRetries?: number;
+  /**
+   * Cap (ms) on any single backoff sleep. The Azure-supplied `Retry-After`
+   * header is honored exactly when present; otherwise an exponentially
+   * growing jittered sleep is used, capped at this value. Defaults to
+   * 30000ms (30s).
+   */
+  retryBackoffMs?: number;
+}
+
+/** Result the translate-call shape must satisfy for retry to function. */
+export interface RetryableResponse {
+  status: string | number;
+  // `any` here so the SDK's narrower `Record<string, string>` headers type
+  // (RawHttpHeaders) still satisfies the constraint without forcing callers
+  // to widen their response types. The retry helper only ever reads via
+  // `parseRetryAfter` which is itself permissive.
+  headers?: Record<string, any>;
+}
+
+/**
+ * Parses an HTTP `Retry-After` header — RFC 7231 allows either a delta in
+ * seconds or an HTTP-date. Returns `undefined` when the value is missing or
+ * unparseable so callers can fall back to exponential backoff.
+ */
+export const parseRetryAfter = (
+  headers: RetryableResponse["headers"] | undefined,
+  now: number = Date.now(),
+): number | undefined => {
+  if (!headers) return undefined;
+  const raw = pickHeader(headers, "retry-after");
+  if (!raw) return undefined;
+
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+
+  // delta-seconds form
+  if (/^\d+(\.\d+)?$/.test(trimmed)) {
+    const seconds = Number.parseFloat(trimmed);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return Math.round(seconds * 1000);
+    }
+  }
+
+  // HTTP-date form
+  const ts = Date.parse(trimmed);
+  if (Number.isFinite(ts)) {
+    const delta = ts - now;
+    return delta > 0 ? delta : 0;
+  }
+  return undefined;
+};
+
+const pickHeader = (
+  headers: NonNullable<RetryableResponse["headers"]>,
+  name: string,
+): string | undefined => {
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== lower) continue;
+    if (Array.isArray(value)) return value[0];
+    return value as string | undefined;
+  }
+  return undefined;
+};
+
+/**
+ * Async sleep helper. Exposed for tests so they can `jest.useFakeTimers()`.
+ */
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Executes `fn` and, when its returned response carries a transient HTTP
+ * status, schedules another attempt. The backoff strategy honors
+ * `Retry-After` headers when present, otherwise applies jittered exponential
+ * backoff (`min(retryBackoffMs, 2^attempt * 500ms +/- 250ms)`).
+ *
+ * Permanent (non-transient) failures and successful responses both flow
+ * straight back to the caller. The wrapper never throws; callers continue to
+ * inspect `isUnexpected(response)` themselves to decide what to do with the
+ * final response.
+ */
+export const retryablePost = async <T extends RetryableResponse>(
+  fn: () => PromiseLike<T>,
+  isTransient: (response: T) => boolean,
+  options?: RetryOptions,
+  /** Injected only for tests; defaults to the real `sleep`. */
+  sleepFn: (ms: number) => Promise<void> = sleep,
+): Promise<T> => {
+  const maxRetries = Math.max(0, options?.maxRetries ?? 5);
+  const cap = Math.max(0, options?.retryBackoffMs ?? 30000);
+
+  let attempt = 0;
+  let response = await fn();
+
+  while (isTransient(response) && attempt < maxRetries) {
+    const status = Number(response.status);
+    const retryAfterMs = parseRetryAfter(response.headers);
+    const expBackoff = Math.min(
+      cap,
+      Math.round(2 ** attempt * 500 + (Math.random() - 0.5) * 500),
+    );
+    const sleepMs = Math.min(cap, retryAfterMs ?? expBackoff);
+
+    warning(
+      `Translator returned HTTP ${status} (attempt ${
+        attempt + 1
+      } of ${maxRetries}). Sleeping ${sleepMs}ms before retrying${
+        retryAfterMs !== undefined ? " (Retry-After honored)" : ""
+      }.`,
+    );
+
+    await sleepFn(Math.max(0, sleepMs));
+    attempt++;
+    response = await fn();
+  }
+
+  return response;
+};
+
+/**
+ * Default predicate matching the codes we treat as transient. Exposed so
+ * call sites that already have an `isUnexpected`-style guard can compose
+ * the two cleanly: only retry when the response is BOTH unexpected AND
+ * carries a transient status.
+ */
+export const isTransientStatus = (status: string | number): boolean => {
+  const n = typeof status === "number" ? status : Number.parseInt(status, 10);
+  return Number.isFinite(n) && TRANSIENT_STATUSES.has(n);
+};

--- a/src/resource-translator.ts
+++ b/src/resource-translator.ts
@@ -7,6 +7,7 @@ import {
   warning,
 } from "@actions/core";
 import { existsSync } from "fs";
+import { minimatch } from "minimatch";
 import { Summary } from "./abstractions/summary";
 import { TranslationFileKind } from "./abstractions/translation-file-kind";
 import { Inputs } from "./action/inputs";
@@ -22,6 +23,41 @@ import {
 } from "./helpers/utils";
 import { readFile, writeFile } from "./io/reader-writer";
 import { findAllTranslationFiles } from "./io/translation-file-finder";
+
+/**
+ * Returns a copy of the input text map with any keys matching `patterns`
+ * stripped. The patterns are matched against the keys returned by each
+ * parser's `toTranslatableTextMap`:
+ *   - resx:    `name` attribute
+ *   - po:      `msgid`
+ *   - xliff:   unit `id`
+ *   - json:    `[--]`-joined dotted path
+ *   - ini/restext: raw key
+ *
+ * Stripped keys are still present in the parsed file content, so they fall
+ * through unchanged when `applyTranslations` overlays the locale data.
+ */
+const filterNoTranslateKeys = (
+  text: Map<string, string>,
+  patterns: string[] | undefined,
+): { filtered: Map<string, string>; skipped: number } => {
+  if (!patterns || patterns.length === 0) {
+    return { filtered: text, skipped: 0 };
+  }
+  const filtered = new Map<string, string>();
+  let skipped = 0;
+  for (const [key, value] of text) {
+    const matchesAny = patterns.some((p) =>
+      minimatch(key, p, { dot: true, nocase: false }),
+    );
+    if (matchesAny) {
+      skipped++;
+      continue;
+    }
+    filtered.set(key, value);
+  }
+  return { filtered, skipped };
+};
 
 export async function start(inputs: Inputs) {
   const failOnError = inputs.failOnError ?? true;
@@ -127,11 +163,33 @@ export async function start(inputs: Inputs) {
             continue;
           }
 
+          const { filtered, skipped } = filterNoTranslateKeys(
+            translatableTextMap.text,
+            inputs.noTranslatePatterns,
+          );
+          if (skipped > 0) {
+            debug(
+              `Skipped ${skipped} key(s) in ${filePath} due to noTranslatePatterns.`,
+            );
+          }
+          if (filtered.size === 0) {
+            debug(
+              `All translatable keys in ${filePath} were excluded by noTranslatePatterns; skipping translate call.`,
+            );
+            continue;
+          }
+
           const resultSet = await translate(
             translatorResource,
             toLocales,
-            translatableTextMap.text,
+            filtered,
             filePath,
+            {
+              protectPlaceholders: inputs.protectPlaceholders,
+              customPlaceholderPatterns: inputs.customPlaceholderPatterns,
+              maxRetries: inputs.maxRetries,
+              retryBackoffMs: inputs.retryBackoffMs,
+            },
           );
 
           debug(`Translation result:\n ${JSON.stringify(resultSet)}`);
@@ -141,7 +199,7 @@ export async function start(inputs: Inputs) {
             continue;
           }
 
-          const length = translatableTextMap.text.size;
+          const length = filtered.size;
           debug(
             `Translation count: ${length}, toLocales size: ${toLocales.length}`,
           );


### PR DESCRIPTION
Implements the three real gaps surfaced during the closed-issue triage:

### Closes #46 — 429 / transient retry
- New `src/helpers/retry.ts` wraps the Translator `client.path("/translate").post()` call.
- Retries on transient HTTP statuses (`408, 425, 429, 500, 502, 503, 504`).
- Honors Azure's `Retry-After` header exactly when present (delta-seconds *or* HTTP-date).
- Falls back to jittered exponential backoff when absent (`min(retryBackoffMs, 2^attempt × 500ms ± 250ms)`).
- Tunable via two new inputs: `maxRetries` (default `5`) and `retryBackoffMs` (default `30000`).

### Closes #35 — opt out of translating specific keys
- New `noTranslatePatterns` input takes newline-separated globs.
- Matched against parser-level keys: JSON `[--]` dotted path, RESX `name`, PO `msgid`, XLIFF unit `id`, INI/restext key.
- Matching keys are dropped from the Translator request entirely; their source values flow through unchanged.

### Tightens #16 — i18next placeholder protection
- New `src/helpers/placeholders.ts` replaces tokens like `{{name}}`, `${var}`, `{0}`, `{0:N2}`, `%s`, `%1$s` and HTML entities with stable `RTKEEP000001`-style ASCII sentinels before translation, then restores them afterward.
- ON by default; toggle via `protectPlaceholders`. Extend the default pattern set via `customPlaceholderPatterns`.
- Sentinel format is plain ASCII numeric so it survives every Translator target language unchanged.

### Wiring
- `src/api/translation-api.ts` gains an optional 5th `TranslateOptions` parameter and calls `protect()` per input value (in lockstep with `values()` iteration order, which Translator preserves), then `restore()` per response row inside each batch.
- The retry wrapper composes with the existing `isUnexpected` guard: **transient + unexpected → retry**, **non-transient unexpected → surface the error as today**.
- `src/resource-translator.ts` filters `translatableTextMap.text` via `minimatch` (already a transitive dep) against `inputs.noTranslatePatterns` before calling `translate()`, and forwards the four new options.

### Tests
- 54 new unit tests across `__tests__/helpers/placeholders.test.ts`, `__tests__/helpers/retry.test.ts`, plus retry-on-429 and placeholder round-trip cases in `__tests__/api.test.ts` and input-parsing coverage in `__tests__/get-inputs.test.ts`.
- **204/204 tests pass.** Coverage held at ~87% statements / ~88% lines.

### Docs
- New "Resilience & placeholder protection" section in `inputs.astro` and `configuration.astro` covering all five new inputs.
- Closed-issue references called out in `CHANGELOG.md` and the docs changelog page.

### Verification
- `npm run verify` (lint + format + test + build) passes locally.
- `dist/resource-translator/index.js` rebuilt and committed.